### PR TITLE
Fixes typo on quickstart page

### DIFF
--- a/docs/user/quickstart.rst
+++ b/docs/user/quickstart.rst
@@ -155,7 +155,7 @@ samples to get an estimate of the density that you were sampling:
 
     for i in range(ndim):
         pl.figure()
-        pl.hist(sampler.flatchain[:,0], 100, color="k", histtype="step")
+        pl.hist(sampler.flatchain[:,i], 100, color="k", histtype="step")
         pl.title("Dimension {0:d}".format(i))
 
     pl.show()


### PR DESCRIPTION
This might be the smallest pull request ever submitted, but on the quickstart page in the emcee docs you have:

```
import matplotlib.pyplot as pl

for i in range(ndim):
    pl.figure()
    pl.hist(sampler.flatchain[:,0], 100, color="k", histtype="step")
    pl.title("Dimension {0:d}".format(i))

pl.show() 
```

Where the 0 in the flatchain slicing should be an i:

```
import matplotlib.pyplot as pl

for i in range(ndim):
    pl.figure()
    pl.hist(sampler.flatchain[:,i], 100, color="k", histtype="step")
    pl.title("Dimension {0:d}".format(i))

pl.show() 
```
