### PR TITLE
Add a pickle() method to EnsembleSampler

### DIFF
--- a/emcee/__init__.py
+++ b/emcee/__init__.py
@@ -20,7 +20,8 @@ def test():
                   ("Parallel Sampler",    "test_parallel"),
                   ("Ensemble Sampler",    "test_ensemble"),
                   ("Metropolis-Hastings", "test_mh"),
-                  ("Parallel Tempering", "test_pt_sampler")
+                  ("Parallel Tempering", "test_pt_sampler"),
+                  ("Pickling", "test_pickle")
                  ]
 
     print("Starting tests...")

--- a/emcee/ensemble.py
+++ b/emcee/ensemble.py
@@ -13,6 +13,7 @@ from __future__ import (division, print_function, absolute_import,
 
 __all__ = ["EnsembleSampler"]
 
+import os
 import multiprocessing
 import numpy as np
 
@@ -448,6 +449,28 @@ class EnsembleSampler(Sampler):
             t[i] = acor.acor(self.chain[:, :, i])[0]
         return t
 
+    def pickle(self, filename, clobber=False):
+        """ Pickle the sampler. """
+        import cPickle as pickle
+
+        if os.path.exists(filename) and not clobber:
+            raise IOError("File '{0}' already exists! If you want to "
+                          "overwrite, use 'clobber=True'"
+                          .format(filename))
+
+        elif os.path.exists(filename) and clobber:
+            os.remove(filename)
+        
+        pool = None
+        if self.pool != None:
+            pool = self.pool
+            self.pool = None
+        
+        with open(filename, "w") as f:
+            pickle.dump(self,f)
+        
+        if pool != None:
+            self.pool = pool            
 
 class _function_wrapper(object):
     """

--- a/emcee/tests.py
+++ b/emcee/tests.py
@@ -243,28 +243,30 @@ class Tests:
         # Make sure that the blobs aren't all the same.
         blobs = self.sampler.blobs
         assert np.any([blobs[-1] != blobs[i] for i in range(len(blobs) - 1)])
-    
+
     def test_pickle(self):
         self.sampler = EnsembleSampler(self.nwalkers, self.ndim,
                                        lnprob_gaussian, args=[self.icov])
         self.check_sampler()
-        
+
         test_pickle_filename = "/tmp/sampler_test.pickle"
         self.sampler.pickle(test_pickle_filename, clobber=True)
-        
+
         assert os.path.exists(test_pickle_filename), "Pickle file not created!"
-        
+
         # -- Now try with multiple processors
         import multiprocessing
         if multiprocessing.cpu_count() == 1:
             return
-            
+
         self.sampler = EnsembleSampler(self.nwalkers, self.ndim,
                                        lnprob_gaussian, args=[self.icov],
                                        threads=2)
         self.check_sampler()
-        
+
         test_pickle_filename = "/tmp/sampler_test.pickle"
         self.sampler.pickle(test_pickle_filename, clobber=True)
-        
+
         assert os.path.exists(test_pickle_filename), "Pickle file not created!"
+
+        os.remove(test_pickle_filename)

--- a/emcee/tests.py
+++ b/emcee/tests.py
@@ -5,6 +5,7 @@ Defines various nose unit tests
 
 """
 
+import os
 import numpy as np
 
 from .mh import MHSampler
@@ -242,3 +243,28 @@ class Tests:
         # Make sure that the blobs aren't all the same.
         blobs = self.sampler.blobs
         assert np.any([blobs[-1] != blobs[i] for i in range(len(blobs) - 1)])
+    
+    def test_pickle(self):
+        self.sampler = EnsembleSampler(self.nwalkers, self.ndim,
+                                       lnprob_gaussian, args=[self.icov])
+        self.check_sampler()
+        
+        test_pickle_filename = "/tmp/sampler_test.pickle"
+        self.sampler.pickle(test_pickle_filename, clobber=True)
+        
+        assert os.path.exists(test_pickle_filename), "Pickle file not created!"
+        
+        # -- Now try with multiple processors
+        import multiprocessing
+        if multiprocessing.cpu_count() == 1:
+            return
+            
+        self.sampler = EnsembleSampler(self.nwalkers, self.ndim,
+                                       lnprob_gaussian, args=[self.icov],
+                                       threads=2)
+        self.check_sampler()
+        
+        test_pickle_filename = "/tmp/sampler_test.pickle"
+        self.sampler.pickle(test_pickle_filename, clobber=True)
+        
+        assert os.path.exists(test_pickle_filename), "Pickle file not created!"


### PR DESCRIPTION
Trying to pickle an `EnsembleSampler` fails when it has an associated multiprocessing pool (because pools can't be serialized). This is just a little hack to pull out the `pool` attribute, pickle the sampler, then put the pool back...
