### PR TITLE
Require numpy >= 1.6.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
                     + open("HISTORY.rst").read(),
     package_data={"": ["LICENSE", "AUTHORS.rst"]},
     include_package_data=True,
-    install_requires=["numpy"],
+    install_requires=["numpy >= 1.6.0"],
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Intended Audience :: Developers",


### PR DESCRIPTION
The function `numpy.count_nonzero`, used in `emcee.ptsampler`, was
introduced in Numpy 1.6.0.
