### PR TITLE
documentation clarification on EnsembleSampler and multiprocessing

### DIFF
--- a/docs/user/advanced.rst
+++ b/docs/user/advanced.rst
@@ -41,11 +41,11 @@ integer greater than 1:
 
 ::
 
-    sampler = emcee.EnsembleSampler(nwalkers, ndim, lnprobfn, threads=15)
+    sampler = emcee.EnsembleSampler(nwalkers, ndim, lnpostfn, threads=15)
 
 In practice, the parallelization is implemented using the built in Python
 `multiprocessing <http://docs.python.org/library/multiprocessing.html>`_
-module. With this comes a few constraints. In particular, both ``lnprobfn``
+module. With this comes a few constraints. In particular, both ``lnpostfn``
 and ``args`` must be `pickleable
 <http://docs.python.org/library/pickle.html#what-can-be-pickled-and-unpickled>`_.
 The exceptions thrown while using ``multiprocessing`` can be quite cryptic
@@ -53,7 +53,9 @@ and even though we've tried to make this feature as user-friendly as possible,
 it can sometimes cause some headaches. One useful debugging tactic is to
 try running with 1 thread if your processes start to crash. This will
 generally provide much more illuminating error messages than in the parallel
-case.
+case. Note that the :class:`EnsembleSampler` sampler object itself is not
+pickleable, so if it or an object that contains it is passed to the lnpostfn
+function and multiprocessing is turned on, the code will fail.
 
 It is also important to note that the ``multiprocessing`` module works by
 spawning a large number of new ``python`` processes and running the code in


### PR DESCRIPTION
Adding a note that the EnsembleSampler is not pickleable. Has the function parameter name changed? It's written as `lnprobfn` and `lnpostfn` in various places.
