### PR TITLE
Add clear_blobs() to ensemble.py

### DIFF
--- a/emcee/ensemble.py
+++ b/emcee/ensemble.py
@@ -94,6 +94,13 @@ class EnsembleSampler(Sampler):
         if self.threads > 1 and self.pool is None:
             self.pool = multiprocessing.Pool(self.threads)
 
+    def clear_blobs(self):
+        """
+        Clear the ``blobs`` list. 
+
+        """
+        self._blobs = []
+
     def reset(self):
         """
         Clear the ``chain`` and ``lnprobability`` array. Also reset the
@@ -106,7 +113,7 @@ class EnsembleSampler(Sampler):
         self._lnprob = np.empty((self.k, 0))
 
         # Initialize list for storing optional metadata blobs.
-        self._blobs = []
+        self.clear_blobs()
 
     def sample(self, p0, lnprob0=None, rstate0=None, blobs0=None,
                iterations=1, thin=1, storechain=True, mh_proposal=None):


### PR DESCRIPTION
I am using the "blobs" functionality to store the results of my models during MCMC computation (I am fitting interferometric data of protoplanetary disks). 
I have fixed a problem arising when the blobs have a large size (for example GB). Since my blobs are of several GB, I've found that emcee stores ALL the blobs of ALL the steps of the run, thus provoking an always increasing usage of RAM. For example, in my main script I have:
  def lnprob:
    …heavy calculations…
    …chi square computation…
  return dlnprob, blobs

  while i<nstep_tot:
    pos, prob, state, blobs = sampler.run_mcmc(pos, n, rstate0=state)
    ...makes a dump of the blobs...
    i+=n

Now, if nstep_tot=1000, I've discovered that the sampler maintains in the RAM all the 1000 blobs (not only the last n), inexorably occupying more and more memory, clearly exceeding the RAM available in any computer. As a consequence, the code always crashes at a certain point because it goes out of memory.

For this, I added the function self.clear_blobs() that can be called from the main script and that simply deletes the blobs array, thus freeing the memory. So, in the main script the while-loop can be changed accordingly:

  while i<nstep_tot:
    sampler.clear_blobs()
    pos, prob, state, blobs = sampler.run_mcmc(pos, n, rstate0=state)
    ...makes a dump of the blobs...
    i+=n

Calling clear_blobs() fixes the problem. I've tested that it works with a memory intensive computation.
As an example, in this way, putting n=1, the sampler occupies only the memory needed to store the blobs of 1 step, that is a quite good solution.

Potential of public usefulness: I am currently working at the European Southern Observatory (ESO) as a PhD student. Talking with other researchers I've realized that the ability to clear the blobs would be appreciated for all of those who have models that produce medium-large datasets of results (such as interferometric data, etc..).
