### PR TITLE
Added Marco Tazzari as an author

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -15,6 +15,7 @@ Direct contributions to the code base:
 - `Adrian Price-Whelan (Columbia) <https://github.com/adrn>`_
 - `Jeremy Sanders (Cambridge) <https://github.com/jeremysanders>`_
 - `Leo Singer (Caltech) <https://github.com/lpsinger>`_
+- `Marco Tazzari (ESO) <https://github.com/mtazzari>`_
 - `Simon Walker <mindriot101>`_
 - `Joe Zuntz (Oxford) <https://github.com/joezuntz>`_
 


### PR DESCRIPTION
Added Marco Tazzari as an author, if he deserves it, for the Clear_blobs() function in ensemble.py, according to what stated in the webpage: "Direct contributions to the code base".
