### PR TITLE
Avoid RuntimeWarning when subtracting infs

### DIFF
--- a/emcee/ensemble.py
+++ b/emcee/ensemble.py
@@ -332,8 +332,8 @@ class EnsembleSampler(Sampler):
         newlnprob, blob = self._get_lnprob(q)
 
         # Decide whether or not the proposals should be accepted.
-        lnpdiff = (self.dim - 1.) * np.log(zz) + newlnprob - lnprob0
-        accept = (lnpdiff > np.log(self._random.rand(len(lnpdiff))))
+        accept = ((self.dim - 1.) * np.log(zz) + newlnprob >
+                  lnprob0 + np.log(self._random.rand(len(lnprob0))))
 
         return q, newlnprob, accept, blob
 


### PR DESCRIPTION
In the _propose_stretch method of EnsembleSampler, occasionally both the new and proposed lnprob values are out of bounds of some prior and set to -np.inf. In cases where newlnprob and lnprob0 are both -np.inf (and type float64),

accept = A + newlnprob - lnprob0 > B

raises a warning for invalid value in subtract. The subtraction evaluates to nan, and accept is set to False.
On the other hand,

accept = A + newlnprob > lnprob0 + B

correctly evaluates to False with no warning. This commit makes that minor manipulation to avoid that warning message.
