### PR TITLE
Add bcast collective operation to the MPIPool class

### DIFF
--- a/emcee/mpi_pool.py
+++ b/emcee/mpi_pool.py
@@ -226,6 +226,12 @@ class MPIPool(object):
 
             return results
 
+    def bcast(self, *args, **kwargs):
+        """
+        Equivalent to mpi4py :func:`bcast` collective operation.
+        """
+        return self.comm.bcast(*args, **kwargs)
+
     def close(self):
         """
         Just send a message off to all the pool members which contains


### PR DESCRIPTION
We often need results in the `master` process to be visible in all the `slaves` for doing _expensive_ post-processing. This patch wraps `mpi4py` bcast operation to avoid `emcee` users going down such useful pool abstraction layer.

**Example of usage:**

``` python
import emcee
import numpy as np

pool = emcee.utils.MPIPool()

if pool.is_master():
    # do MCMC machinery to produce data
    data = np.array([1,2,3])

    # tell slaves to proceed
    pool.close()
else:
    # create dummy variable and wait for instructions
    data = None
    pool.wait()

# broadcast results
results = pool.bcast(data)

# slaves now have the correct data, continue the heavy work...
```
