### PR TITLE
Add a hashbang line to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,6 @@
+#! /usr/bin/env python
+# -*- coding: utf-8 -*-
+
 import os
 import sys
 import re


### PR DESCRIPTION
The script's executable bit is set, so there should be one! If you try to run it on Unix, it invokes the X windows `import` program which is all sorts of bad news.
