### PR TITLE
Rewrite MPIPool class to fix cPickle.UnpicklingError bug

### DIFF
--- a/emcee/mpi_pool.py
+++ b/emcee/mpi_pool.py
@@ -14,236 +14,127 @@ except ImportError:
     MPI = None
 
 
-class _close_pool_message(object):
-    def __repr__(self):
-        return "<Close pool message>"
-
-
-class _function_wrapper(object):
-    def __init__(self, function):
-        self.function = function
-
-
-def _error_function(task):
-    raise RuntimeError("Pool was sent tasks before being told what "
-                       "function to apply.")
-
-
 class MPIPool(object):
     """
-    A pool that distributes tasks over a set of MPI processes. MPI is an
-    API for distributed memory parallelism.  This pool will let you run
-    emcee without shared memory, letting you use much larger machines
-    with emcee.
+    MPI-based parallel processing pool with dynamic load balancing
 
-    The pool only support the :func:`map` method at the moment because
-    this is the only functionality that emcee needs. That being said,
-    this pool is fairly general and it could be used for other purposes.
+    Design pattern in which a master process distributes tasks to other
+    processes (a.k.a. workers) within a MPI communicator.
 
-    Contributed by `Joe Zuntz <https://github.com/joezuntz>`_.
+    Parameters
+    ----------
+    :param comm: ``mpi4py`` communicator (optional)
+        MPI communicator for transmitting messages
+        Default: MPI.COMM_WORLD
 
-    :param comm: (optional)
-        The ``mpi4py`` communicator.
+    :param master: int (optional)
+        Master process is one of 0, 1,..., comm.size-1
+        Default: 0
 
-    :param debug: (optional)
-        If ``True``, print out a lot of status updates at each step.
+    :param debug: bool (optional)
+        Whether to print debugging information or not
+        Default: False
 
-    :param loadbalance: (optional)
-        if ``True`` and ntask > Ncpus, tries to loadbalance by sending
-        out one task to each cpu first and then sending out the rest
-        as the cpus get done.
+    Authors
+    -------
+    `Lisandro Dalcin <https://github.com/dalcinl>`_
+    `Júlio Hoffimann <https://github.com/juliohm>`_
+
     """
-    def __init__(self, comm=None, debug=False, loadbalance=False):
+    def __init__(self, comm=MPI.COMM_WORLD, master=0, debug=False):
         if MPI is None:
             raise ImportError("Please install mpi4py")
 
-        self.comm = MPI.COMM_WORLD if comm is None else comm
-        self.rank = self.comm.Get_rank()
-        self.size = self.comm.Get_size() - 1
+        assert comm.size > 1, "MPI pool must have at least 2 processes"
+        assert 0 <= master < comm.size, "Master process must be in range [0,comm.size)"
+        self.comm = comm
+        self.master = master
         self.debug = debug
-        self.function = _error_function
-        self.loadbalance = loadbalance
-        if self.size == 0:
-            raise ValueError("Tried to create an MPI pool, but there "
-                             "was only one MPI process available. "
-                             "Need at least two.")
+        self.workers = set(range(comm.size))
+        self.workers.discard(self.master)
+
 
     def is_master(self):
         """
-        Is the current process the master?
+        Returns true if on the master process, false otherwise.
 
         """
-        return self.rank == 0
+        return self.comm.rank == self.master
+
 
     def wait(self):
         """
-        If this isn't the master process, wait for instructions.
+        Make the workers listen to the master.
 
         """
-        if self.is_master():
-            raise RuntimeError("Master node told to await jobs.")
-
+        if self.is_master(): return
+        worker = self.comm.rank
         status = MPI.Status()
-
         while True:
-            # Event loop.
-            # Sit here and await instructions.
-            if self.debug:
-                print("Worker {0} waiting for task.".format(self.rank))
+            if self.debug: print("Worker {0} waiting for task".format(worker))
+            task = self.comm.recv(source=self.master, tag=MPI.ANY_TAG, status=status)
 
-            # Blocking receive to wait for instructions.
-            task = self.comm.recv(source=0, tag=MPI.ANY_TAG, status=status)
-            if self.debug:
-                print("Worker {0} got task {1} with tag {2}."
-                      .format(self.rank, task, status.tag))
-
-            # Check if message is special sentinel signaling end.
-            # If so, stop.
-            if isinstance(task, _close_pool_message):
-                if self.debug:
-                    print("Worker {0} told to quit.".format(self.rank))
+            if task is None:
+                if self.debug: print("Worker {0} told to quit work".format(worker))
                 break
 
-            # Check if message is special type containing new function
-            # to be applied
-            if isinstance(task, _function_wrapper):
-                self.function = task.function
-                if self.debug:
-                    print("Worker {0} replaced its task function: {1}."
-                          .format(self.rank, self.function))
-                continue
+            func, arg = task
+            if self.debug: print("Worker {0} got task {1} with tag {2}"
+                                 .format(worker, arg, status.tag))
 
-            # If not a special message, just run the known function on
-            # the input and return it asynchronously.
-            result = self.function(task)
-            if self.debug:
-                print("Worker {0} sending answer {1} with tag {2}."
-                      .format(self.rank, result, status.tag))
-            self.comm.isend(result, dest=0, tag=status.tag)
+            result = func(arg)
 
-    def map(self, function, tasks):
+            if self.debug: print("Worker {0} sending answer {1} with tag {2}"
+                                 .format(worker, result, status.tag))
+            self.comm.ssend(result, self.master, status.tag)
+
+
+    def map(self, func, iterable):
         """
-        Like the built-in :func:`map` function, apply a function to all
-        of the values in a list and return the list of results.
-
-        :param function:
-            The function to apply to the list.
-
-        :param tasks:
-            The list of elements.
+        Evaluate a function at various points in parallel. Results are
+        returned in the requested order (i.e. y[i] = f(x[i])).
 
         """
-        ntask = len(tasks)
+        assert self.is_master()
 
-        # If not the master just wait for instructions.
-        if not self.is_master():
-            self.wait()
-            return
+        workerset = self.workers.copy()
+        tasklist = [(tid, (func, arg)) for tid, arg in enumerate(iterable)]
+        resultlist = [None] * len(tasklist)
+        pending = len(tasklist)
 
-        if function is not self.function:
-            if self.debug:
-                print("Master replacing pool function with {0}."
-                      .format(function))
+        while pending:
+            if workerset and tasklist:
+                worker = workerset.pop()
+                taskid, task = tasklist.pop()
+                if self.debug: print("Sent task {0} to worker {1} with tag {2}"
+                                     .format(task[1], worker, taskid))
+                self.comm.send(task, dest=worker, tag=taskid)
 
-            self.function = function
-            F = _function_wrapper(function)
+            if tasklist:
+                flag = self.comm.Iprobe(source=MPI.ANY_SOURCE, tag=MPI.ANY_TAG)
+                if not flag: continue
+            else:
+                self.comm.Probe(source=MPI.ANY_SOURCE, tag=MPI.ANY_TAG)
 
-            # Tell all the workers what function to use.
-            requests = []
-            for i in range(self.size):
-                r = self.comm.isend(F, dest=i + 1)
-                requests.append(r)
+            status = MPI.Status()
+            result = self.comm.recv(source=MPI.ANY_SOURCE, tag=MPI.ANY_TAG, status=status)
+            worker = status.source
+            taskid = status.tag
+            if self.debug: print("Master received from worker {0} with tag {1}"
+                                 .format(worker, taskid))
 
-            # Wait until all of the workers have responded. See:
-            #       https://gist.github.com/4176241
-            MPI.Request.waitall(requests)
+            workerset.add(worker)
+            resultlist[taskid] = result
+            pending -= 1
 
-        if (not self.loadbalance) or (ntask <= self.size):
-            # Do not perform load-balancing - the default load-balancing
-            # scheme emcee uses.
+        return resultlist
 
-            # Send all the tasks off and wait for them to be received.
-            # Again, see the bug in the above gist.
-            requests = []
-            for i, task in enumerate(tasks):
-                worker = i % self.size + 1
-                if self.debug:
-                    print("Sent task {0} to worker {1} with tag {2}."
-                          .format(task, worker, i))
-                r = self.comm.isend(task, dest=worker, tag=i)
-                requests.append(r)
 
-            MPI.Request.waitall(requests)
-
-            # Now wait for the answers.
-            results = []
-            for i in range(ntask):
-                worker = i % self.size + 1
-                if self.debug:
-                    print("Master waiting for worker {0} with tag {1}"
-                          .format(worker, i))
-                result = self.comm.recv(source=worker, tag=i)
-                results.append(result)
-
-            return results
-
-        else:
-            # Perform load-balancing. The order of the results are likely to
-            # be different from the previous case.
-            for i, task in enumerate(tasks[0:self.size]):
-                worker = i+1
-                if self.debug:
-                    print("Sent task {0} to worker {1} with tag {2}."
-                          .format(task, worker, i))
-                # Send out the tasks asynchronously.
-                self.comm.isend(task, dest=worker, tag=i)
-
-            ntasks_dispatched = self.size
-            results = [None]*ntask
-            for itask in range(ntask):
-                status = MPI.Status()
-                # Receive input from workers.
-                result = self.comm.recv(source=MPI.ANY_SOURCE,
-                                        tag=MPI.ANY_TAG, status=status)
-                worker = status.source
-                i = status.tag
-                results[i] = result
-                if self.debug:
-                    print("Master received from worker {0} with tag {1}"
-                          .format(worker, i))
-
-                # Now send the next task to this idle worker (if there are any
-                # left).
-                if ntasks_dispatched < ntask:
-                    task = tasks[ntasks_dispatched]
-                    i = ntasks_dispatched
-                    if self.debug:
-                        print("Sent task {0} to worker {1} with tag {2}."
-                              .format(task, worker, i))
-                    # Send out the tasks asynchronously.
-                    self.comm.isend(task, dest=worker, tag=i)
-                    ntasks_dispatched += 1
-
-            return results
-
-    def bcast(self, *args, **kwargs):
+    def proceed(self):
         """
-        Equivalent to mpi4py :func:`bcast` collective operation.
-        """
-        return self.comm.bcast(*args, **kwargs)
-
-    def close(self):
-        """
-        Just send a message off to all the pool members which contains
-        the special :class:`_close_pool_message` sentinel.
+        Tell all the workers to quit work.
 
         """
-        if self.is_master():
-            for i in range(self.size):
-                self.comm.isend(_close_pool_message(), dest=i + 1)
-
-    def __enter__(self):
-        return self
-
-    def __exit__(self, *args):
-        self.close()
+        if not self.is_master(): return
+        for worker in self.workers:
+            self.comm.send(None, worker, 0)


### PR DESCRIPTION
This pull request fixes the `cPickleUnpicklingError` described in [this gist](https://gist.github.com/dfm/4176241).

The problem is quite obscure, but it was fixed after some discussion with the `mpi4py` maintainer Lisandro Dalcin (a.k.a. @dalcinl). What happens is that some MPI implementations (e.g. OpenMPI, Bull MPI) doesn't guarantee buffered messages to be arbitrarily large (i.e. `isend()` calls).

The method `close()` was further renamed to the more intuitive verb `proceed()`. The `map()` function now can only be called from the master process by design. This has great usability impact as there is no need anymore to `bcast()` data to all slaves or create dummy variables `data=None` right before `map(func, data)` calls.
