### PR TITLE
Added reset_burn_in

### DIFF
--- a/emcee/sampler.py
+++ b/emcee/sampler.py
@@ -124,6 +124,15 @@ class Sampler(object):
         self.naccepted = 0
         self._last_run_mcmc_result = None
 
+    def reset_burn_in(self):
+        """
+        Clear the chain, while remember the last result from ``run_mcmc``.  This
+        allows running for a burnin period and then resuming with
+        ``sampler.run_mcmc(None, niters)``.
+        """
+        self.iterations = 0
+        self.naccepted = 0
+
     def clear_chain(self):
         """An alias for :func:`reset` kept for backwards compatibility."""
         return self.reset()

--- a/emcee/sampler.py
+++ b/emcee/sampler.py
@@ -130,8 +130,9 @@ class Sampler(object):
         allows running for a burnin period and then resuming with
         ``sampler.run_mcmc(None, niters)``.
         """
-        self.iterations = 0
-        self.naccepted = 0
+        temp_last_run_mcmc_result = self._last_run_mcmc_result
+        self.reset()
+        self._last_run_mcmc_result = temp_last_run_mcmc_result
 
     def clear_chain(self):
         """An alias for :func:`reset` kept for backwards compatibility."""

--- a/emcee/tests.py
+++ b/emcee/tests.py
@@ -279,3 +279,18 @@ class Tests:
         # None is given and that it records whatever it does
         s.run_mcmc(None, N=self.N)
         assert s.chain.shape[1] == 2 * self.N
+
+        # also make sure `reset_burn_in` still allows ``run_mcmc(None)``, but
+        # resets the chain
+        s.reset_burn_in()
+        s.run_mcmc(None, N=self.N)
+        assert s.chain.shape[1] == self.N
+
+        #and ensure regular `reset` does *not*
+        s.reset()
+        try:
+            s.run_mcmc(None, N=1)
+            assert False, 'run_mcmc ran after reset - that should be impossible!'
+        except ValueError:
+            # it *should* raise a ValueError
+            pass


### PR DESCRIPTION
This does what  #128 suggests and adds a `reset_burn_in` method.  So I think this closes #128

@dfm, I confess I don't understand why this works: I'm just reproducing the "old" `reset` prior to #124, but I don't fully understand why setting `iterations` and `naccepted` to 0 resets the chain... But I assume that's the right way since it worked before? 

cc @ipashchenko
