### PR TITLE
Improve the td integration method in ptsampler

### DIFF
--- a/emcee/ptsampler.py
+++ b/emcee/ptsampler.py
@@ -465,16 +465,16 @@ class PTSampler(Sampler):
             return self.thermodynamic_integration_log_evidence(
                 logls=self.lnlikelihood, fburnin=fburnin)
         else:
-            betas = np.concatenate((self.betas, np.array([0])))
-            betas2 = np.concatenate((self.betas[::2], np.array([0])))
+            betas = self.betas
+            betas2 = self.betas[::2]
 
             istart = int(logls.shape[2] * fburnin + 0.5)
 
             mean_logls = np.mean(np.mean(logls, axis=1)[:, istart:], axis=1)
             mean_logls2 = mean_logls[::2]
 
-            lnZ = -np.dot(mean_logls, np.diff(betas))
-            lnZ2 = -np.dot(mean_logls2, np.diff(betas2))
+            lnZ = np.trapz(mean_logls, betas)
+            lnZ2 = np.trapz(mean_logls2, betas2)
 
             return lnZ, np.abs(lnZ - lnZ2)
 

--- a/emcee/ptsampler.py
+++ b/emcee/ptsampler.py
@@ -473,8 +473,8 @@ class PTSampler(Sampler):
             mean_logls = np.mean(np.mean(logls, axis=1)[:, istart:], axis=1)
             mean_logls2 = mean_logls[::2]
 
-            lnZ = np.trapz(mean_logls, betas)
-            lnZ2 = np.trapz(mean_logls2, betas2)
+            lnZ = -np.trapz(mean_logls, betas)
+            lnZ2 = -np.trapz(mean_logls2, betas2)
 
             return lnZ, np.abs(lnZ - lnZ2)
 


### PR DESCRIPTION
Previously this used a simple quadrature, but this introduced a bug
which tended to end in overestimates of the evidence. Replacing this
with numpy's trapz rule avoid this bug and improves the readability

@farr : Could you take a look at this and check I haven't misunderstood
the original code?