### PR TITLE
Fix PTSampler.run_mcmc()

### DIFF
--- a/emcee/mh.py
+++ b/emcee/mh.py
@@ -50,7 +50,7 @@ class MHSampler(Sampler):
         self._chain = np.empty((0, self.dim))
         self._lnprob = np.empty(0)
 
-    def sample(self, p0, lnprob=None, randomstate=None, thin=1,
+    def sample(self, p0, lnprob=None, rstate0=None, thin=1,
                storechain=True, iterations=1):
         """
         Advances the chain ``iterations`` steps as an iterator
@@ -91,7 +91,7 @@ class MHSampler(Sampler):
 
         """
 
-        self.random_state = randomstate
+        self.random_state = rstate0
 
         p = np.array(p0)
         if lnprob is None:

--- a/emcee/ptsampler.py
+++ b/emcee/ptsampler.py
@@ -210,7 +210,7 @@ class PTSampler(Sampler):
         self._lnprob = None
         self._lnlikelihood = None
 
-    def sample(self, p0, lnprob0=None, lnlike0=None, iterations=1,
+    def sample(self, p0, lnprob0=None, lnlike0=None, rstate0=None, iterations=1,
                thin=1, storechain=True):
         """
         Advance the chains ``iterations`` steps as a generator.
@@ -226,6 +226,10 @@ class PTSampler(Sampler):
         :param lnlike0: (optional)
             The initial likelihood values for the ensembles.  Shape
             ``(ntemps, nwalkers)``.
+
+        :param rstate0: (optional)
+            The state of the random number generator.
+            See the :attr:`Sampler.random_state` property for details.
 
         :param iterations: (optional)
             The number of iterations to preform.
@@ -247,6 +251,9 @@ class PTSampler(Sampler):
         * ``lnlike`` the current likelihood values for the walkers.
 
         """
+        # See comments in EnsembleSampler.sample(). Fails silently.
+        self.random_state = rstate0
+
         p = np.copy(np.array(p0))
 
         # If we have no lnprob or logls compute them

--- a/emcee/sampler.py
+++ b/emcee/sampler.py
@@ -168,7 +168,7 @@ class Sampler(object):
             if rstate0 is None:
                 rstate0 = self._last_run_mcmc_result[2]
 
-        for results in self.sample(pos0, lnprob0, rstate0, iterations=N,
+        for results in self.sample(pos0, lnprob0, rstate0=rstate0, iterations=N,
                                    **kwargs):
             pass
 

--- a/emcee/tests.py
+++ b/emcee/tests.py
@@ -159,6 +159,10 @@ class Tests:
         assert np.all((np.cov(chain, rowvar=0) - self.cov) ** 2.0 / N ** 2.0
                       < maxdiff), 'covariance incorrect'
 
+        # PT sampler used to not work with run_mcmc(); check that the trivial
+        # case is OK.
+        self.sampler.run_mcmc (p0, 10, lnlike0=-4)
+
     def test_mh(self):
         self.sampler = MHSampler(self.cov, self.ndim, lnprob_gaussian,
                                  args=[self.icov])


### PR DESCRIPTION
The generic Sampler.run_mcmc() function wouldn't work right for PTSampler
because it passed the RNG state, `rstate0`, as the second positional argument
to sample(), while for PTSampler the second positional argument was the extra
`lnlike0` parameter. If you tried to pass `lnlike0` yourself, then, you'd
get an exception for a doubly-specified keyword.

Anyway, the best solution is probably to pass `rstate0` as a keyword argument so
that subclasses can have differently-ordered arguments if they want. Do that.
This also requires fixing a discrepancy between the documentation and
implemention of the M-H sampler, which claimed the RNG state keyword was
`rstate0` when it was really being called `randomstate`.
