### PR TITLE
Vectorize lnprobfn call

### DIFF
--- a/emcee/ensemble.py
+++ b/emcee/ensemble.py
@@ -79,13 +79,13 @@ class EnsembleSampler(Sampler):
     """
     def __init__(self, nwalkers, dim, lnpostfn, a=2.0, args=[], kwargs={},
                  postargs=None, threads=1, pool=None, live_dangerously=False,
-                 runtime_sortingfn=None):
+                 runtime_sortingfn=None, vectorize=False):
         self.k = nwalkers
         self.a = a
         self.threads = threads
         self.pool = pool
         self.runtime_sortingfn = runtime_sortingfn
-        self.vectorize = False
+        self.vectorize = vectorize
 
         if postargs is not None:
             args = postargs

--- a/emcee/ensemble.py
+++ b/emcee/ensemble.py
@@ -85,7 +85,7 @@ class EnsembleSampler(Sampler):
         self.threads = threads
         self.pool = pool
         self.runtime_sortingfn = runtime_sortingfn
-        self.vectorize = vectorize
+        self.vectorize = vectorize 
 
         if postargs is not None:
             args = postargs

--- a/emcee/ensemble.py
+++ b/emcee/ensemble.py
@@ -85,7 +85,7 @@ class EnsembleSampler(Sampler):
         self.threads = threads
         self.pool = pool
         self.runtime_sortingfn = runtime_sortingfn
-        self.collect_pos = False
+        self.vectorize = False
 
         if postargs is not None:
             args = postargs
@@ -380,8 +380,8 @@ class EnsembleSampler(Sampler):
             p, idx = self.runtime_sortingfn(p)
 
         # Run the log-probability calculations (optionally in parallel).
-        if self.collect_pos == True:
-            # If collect_pos set to true, collect all positions and evaluate lnprobfn in one go
+        if self.vectorize == True:
+            # If vectorize  set to true, collect all positions and evaluate lnprobfn in one go
             results = self.lnprobfn(p)
         else:
             results = list(M(self.lnprobfn, [p[i] for i in range(len(p))]))

--- a/emcee/ensemble.py
+++ b/emcee/ensemble.py
@@ -379,7 +379,11 @@ class EnsembleSampler(Sampler):
             p, idx = self.runtime_sortingfn(p)
 
         # Run the log-probability calculations (optionally in parallel).
-        results = list(M(self.lnprobfn, [p[i] for i in range(len(p))]))
+        if self.collect_pos == True:
+            # If collect_pos set to true, collect all positions and evaluate lnprobfn in one go
+            results = self.lnprobfn(p)
+        else:
+            results = list(M(self.lnprobfn, [p[i] for i in range(len(p))]))
 
         try:
             lnprob = np.array([float(l[0]) for l in results])

--- a/emcee/ensemble.py
+++ b/emcee/ensemble.py
@@ -382,7 +382,7 @@ class EnsembleSampler(Sampler):
         # Run the log-probability calculations (optionally in parallel).
         if self.collect_pos == True:
             # If collect_pos set to true, collect all positions and evaluate lnprobfn in one go
-            results = self.lnprobfn(p.T)
+            results = self.lnprobfn(p)
         else:
             results = list(M(self.lnprobfn, [p[i] for i in range(len(p))]))
 

--- a/emcee/ensemble.py
+++ b/emcee/ensemble.py
@@ -382,7 +382,7 @@ class EnsembleSampler(Sampler):
         # Run the log-probability calculations (optionally in parallel).
         if self.collect_pos == True:
             # If collect_pos set to true, collect all positions and evaluate lnprobfn in one go
-            results = self.lnprobfn(p)
+            results = self.lnprobfn(p.T)
         else:
             results = list(M(self.lnprobfn, [p[i] for i in range(len(p))]))
 

--- a/emcee/ensemble.py
+++ b/emcee/ensemble.py
@@ -85,6 +85,7 @@ class EnsembleSampler(Sampler):
         self.threads = threads
         self.pool = pool
         self.runtime_sortingfn = runtime_sortingfn
+        self.collect_pos = False
 
         if postargs is not None:
             args = postargs


### PR DESCRIPTION
I added the capability to make lnprobfn() call the entire vector p all at once, instead of using map() to iterate over p. For custom lnprobfn() functions that are already highly vectorized, this can bring a large speed-up (for my custom use-case I get over an order of magnitude in speed-up).