### PR TITLE
Adding python 3.6 to the travis matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ python:
   - "3.3"
   - "3.4"
   - "3.5"
+  - "3.6"
 
 install:
   - pip install numpy


### PR DESCRIPTION
I'm having troubles building a python3.6 conda package for emcee, so there may be some compatibility issues. Anyway, it's always useful to test with the latest and greatest....

This is the one I've run into (it's quite possible being upstream, but maybe it can be worked around here): https://ci.appveyor.com/project/Astropy/conda-channel-astropy/build/1.0.447/job/10c7wn6nith6vb4c#L1106
