### PR TITLE
MAINT: fixes gh226, gh182

### DIFF
--- a/emcee/ensemble.py
+++ b/emcee/ensemble.py
@@ -274,7 +274,7 @@ class EnsembleSampler(Sampler):
                             for j in range(len(ind)):
                                 blobs[indfull[j]] = blob[ind[j]]
 
-            if storechain and i % thin == 0:
+            if storechain and (i+1) % thin == 0:
                 ind = i0 + int(i / thin)
                 self._chain[:, ind, :] = p
                 self._lnprob[:, ind] = lnprob

--- a/emcee/tests.py
+++ b/emcee/tests.py
@@ -6,7 +6,6 @@ Defines various nose unit tests
 """
 
 import numpy as np
-import scipy.optimize as op
 
 from .autocorr import integrated_time
 from .mh import MHSampler
@@ -326,7 +325,8 @@ class Tests:
             m, b, lnf = theta
             model = m * x + b
             inv_sigma2 = 1.0 / (yerr ** 2 + model ** 2 * np.exp(2 * lnf))
-            return -0.5 * (np.sum((y - model) ** 2 * inv_sigma2 - np.log(inv_sigma2)))
+            return -0.5 * (np.sum((y - model) ** 2 * inv_sigma2 -
+                                  np.log(inv_sigma2)))
 
         def lnprior(theta):
             m, b, lnf = theta
@@ -341,10 +341,13 @@ class Tests:
             return lp + lnlike(theta, x, y, yerr)
 
         nll = lambda *args: -lnlike(*args)
-        result = op.minimize(nll, [m_true, b_true, np.log(f_true)], args=(x, y, yerr))
+
+        # minimize(nll, [m_true, b_true, np.log(f_true)], args=(x, y, yerr))
+        init_guess = np.array([-0.95612643,  4.23596208, -0.66826006])
 
         ndim, nwalkers = 3, 100
-        pos = [result["x"] + 1e-4 * np.random.randn(ndim) for i in range(nwalkers)]
+        pos = [init_guess + 1e-4 * np.random.randn(ndim) for
+               i in range(nwalkers)]
 
         sampler = EnsembleSampler(nwalkers, ndim, lnprob, args=(x, y, yerr))
         s = sampler.sample(pos, iterations=65, thin=2)

--- a/emcee/tests.py
+++ b/emcee/tests.py
@@ -6,6 +6,7 @@ Defines various nose unit tests
 """
 
 import numpy as np
+import scipy.optimize as op
 
 from .autocorr import integrated_time
 from .mh import MHSampler
@@ -302,4 +303,56 @@ class Tests:
 
         assert np.all(np.abs(acls_multi - acls_single) < 2)
 
-        
+    def test_gh226(self):
+        # EnsembleSampler.sample errors when iterations is not a multiple of thin
+        m_true = -0.9594
+        b_true = 4.294
+        f_true = 0.534
+
+        # Generate some synthetic data from the model.
+        N = 50
+        x = np.sort(10 * np.random.rand(N))
+        yerr = 0.1 + 0.5 * np.random.rand(N)
+        y = m_true * x + b_true
+        y += np.abs(f_true * y) * np.random.randn(N)
+        y += yerr * np.random.randn(N)
+
+        A = np.vstack((np.ones_like(x), x)).T
+        C = np.diag(yerr * yerr)
+        cov = np.linalg.inv(np.dot(A.T, np.linalg.solve(C, A)))
+        b_ls, m_ls = np.dot(cov, np.dot(A.T, np.linalg.solve(C, y)))
+
+        def lnlike(theta, x, y, yerr):
+            m, b, lnf = theta
+            model = m * x + b
+            inv_sigma2 = 1.0 / (yerr ** 2 + model ** 2 * np.exp(2 * lnf))
+            return -0.5 * (np.sum((y - model) ** 2 * inv_sigma2 - np.log(inv_sigma2)))
+
+        def lnprior(theta):
+            m, b, lnf = theta
+            if -5.0 < m < 0.5 and 0.0 < b < 10.0 and -10.0 < lnf < 1.0:
+                return 0.0
+            return -np.inf
+
+        def lnprob(theta, x, y, yerr):
+            lp = lnprior(theta)
+            if not np.isfinite(lp):
+                return -np.inf
+            return lp + lnlike(theta, x, y, yerr)
+
+        nll = lambda *args: -lnlike(*args)
+        result = op.minimize(nll, [m_true, b_true, np.log(f_true)], args=(x, y, yerr))
+
+        ndim, nwalkers = 3, 100
+        pos = [result["x"] + 1e-4 * np.random.randn(ndim) for i in range(nwalkers)]
+
+        sampler = EnsembleSampler(nwalkers, ndim, lnprob, args=(x, y, yerr))
+        s = sampler.sample(pos, iterations=65, thin=2)
+        for i in range(65):
+            next(s)
+        np.testing.assert_equal(sampler.chain.shape, (nwalkers, 32, ndim))
+
+        sampler = EnsembleSampler(nwalkers, ndim, lnprob, args=(x, y, yerr))
+        s = sampler.sample(pos, iterations=65, thin=3)
+        for i in range(65):
+            next(s)


### PR DESCRIPTION
EnsembleSampler.sample raises an IndexError if `iterations` is not a multiple of `thin`. This PR fixes that and adds a test for the bug.