### PR TITLE
use np.isinf instead of not np.isfinite

### DIFF
--- a/docs/user/line.rst
+++ b/docs/user/line.rst
@@ -227,7 +227,7 @@ log-probability function is:
 
     def lnprob(theta, x, y, yerr):
         lp = lnprior(theta)
-        if not np.isfinite(lp):
+        if np.isinf(lp):
             return -np.inf
         return lp + lnlike(theta, x, y, yerr)
 

--- a/examples/line.py
+++ b/examples/line.py
@@ -65,7 +65,7 @@ def lnlike(theta, x, y, yerr):
 
 def lnprob(theta, x, y, yerr):
     lp = lnprior(theta)
-    if not np.isfinite(lp):
+    if np.isinf(lp):
         return -np.inf
     return lp + lnlike(theta, x, y, yerr)
 


### PR DESCRIPTION
I was working through the example and think that `np.isinf` is better than `not np.isfinite`.