### PR TITLE
BUG: compute_log_prob should accept coords=None

### DIFF
--- a/emcee/ensemble.py
+++ b/emcee/ensemble.py
@@ -351,7 +351,7 @@ class EnsembleSampler(object):
         """Calculate the vector of log-probability for the walkers
 
         Args:
-            pos: (Optional[ndarray[..., ndim]]) The position vector in
+            coords: (Optional[ndarray[..., ndim]]) The position vector in
                 parameter space where the probability should be calculated.
                 This defaults to the current position unless a different one
                 is provided.
@@ -365,6 +365,12 @@ class EnsembleSampler(object):
 
         """
         p = coords
+
+        if p is None:
+            if self._last_run_mcmc_result is None:
+                raise ValueError("Cannot have coords=None if run_mcmc has never "
+                                 "been called.")
+            p, log_prob0, rstate0 = self._last_run_mcmc_result[:3]
 
         # Check that the parameters are in physical ranges.
         if np.any(np.isinf(p)):


### PR DESCRIPTION
The docstring for `compute_log_prob` indicates it should work with `coords=None`.  Reproducing code is:

```
import numpy as np
import emcee

def lnprob(x, ivar):
    return -0.5 * np.sum(ivar * x ** 2)

ndim, nwalkers = 10, 100
ivar = 1. / np.random.rand(ndim)
p0 = [np.random.rand(ndim) for i in range(nwalkers)]

sampler = emcee.EnsembleSampler(nwalkers, ndim, lnprob, args=[ivar])
sampler.run_mcmc(p0, 100)
sampler.compute_log_prob()
```