### PR TITLE
Clarify that vectorize disables pool

### DIFF
--- a/emcee/ensemble.py
+++ b/emcee/ensemble.py
@@ -45,7 +45,8 @@ class EnsembleSampler(object):
             as a set of numpy arrays in memory, but new backends can be
             written to support other mediums.
         vectorize (Optional[bool]): If ``True``, ``log_prob_fn`` is expected
-            to accept a list of position vectors instead of just one.
+            to accept a list of position vectors instead of just one. Note
+            that ``pool`` will be ignored if this is ``True``.
             (default: ``False``)
 
     """


### PR DESCRIPTION
Minor docstring item here, but it threw me for a loop while experimenting.  I *think* I'm interpreting the beahvior right, aren't I?