### PR TITLE
Make progress bar optionally use other tqdm pbars

### DIFF
--- a/emcee/ensemble.py
+++ b/emcee/ensemble.py
@@ -201,8 +201,11 @@ class EnsembleSampler(object):
                 chain. If you are using another method to store the samples to
                 a file or if you don't need to analyze the samples after the
                 fact (for burn-in for example) set ``store`` to ``False``.
-            progress (Optional[bool]): If ``True``, a progress bar will be shown
-                as the sampler progresses.
+            progress (Optional[bool or str]): If ``True``, a progress bar will
+                be shown as the sampler progresses. If a string, will select a
+                specific ``tqdm`` progress bar - most notable is ``'notebook'``,
+                which shows a progress bar suitable for Jupyter notebooks.  If
+                ``False``, no progress bar will be shown.
 
 
         Every ``thin_by`` steps, this generator yields the :class:`State` of

--- a/emcee/ensemble.py
+++ b/emcee/ensemble.py
@@ -201,6 +201,9 @@ class EnsembleSampler(object):
                 chain. If you are using another method to store the samples to
                 a file or if you don't need to analyze the samples after the
                 fact (for burn-in for example) set ``store`` to ``False``.
+            progress (Optional[bool]): If ``True``, a progress bar will be shown
+                as the sampler progresses.
+
 
         Every ``thin_by`` steps, this generator yields the :class:`State` of
         the ensemble.

--- a/emcee/pbar.py
+++ b/emcee/pbar.py
@@ -7,7 +7,7 @@ __all__ = ["get_progress_bar"]
 import logging
 
 try:
-    from tqdm import tqdm
+    import tqdm
 except ImportError:
     tqdm = None
 
@@ -34,14 +34,21 @@ def get_progress_bar(display, total):
     bar" that does nothing.
 
     Args:
-        display (bool): Should the bar actually show the progress?
+        display (bool or str): Should the bar actually show the progress? Or a
+                               string to indicate which tqdm bar to use.
         total (int): The total size of the progress bar.
 
     """
-    if not display:
-        return _NoOpPBar()
-    if tqdm is None:
-        logging.warn("You must install the tqdm library to use progress "
-                     "indicators with emcee")
-        return _NoOpPBar()
-    return tqdm(total=total)
+    if display:
+        if tqdm is None:
+            logging.warn("You must install the tqdm library to use progress "
+                         "indicators with emcee")
+            return _NoOpPBar()
+        else:
+            if display is True:
+                return tqdm.tqdm(total=total)
+            else:
+                return getattr(tqdm, 'tqdm_' + display)(total=total)
+
+    return _NoOpPBar()
+


### PR DESCRIPTION
This PR enhances the progress bar support to allow use of some of the other `tqdm` progress bars.

Most notably, this enables ``tqdm_notebook``, which I think is much better when working in the notebook environment.  It also allows ``tqdm_gui``, presumably, although I've not tested it.  And if `tqdm` adds more in the future, it should allow that as long as they follow the ``tqdm.tqdm_<something>`` convention for function names. 