### PR TITLE
State docstring

### DIFF
--- a/docs/user/sampler.rst
+++ b/docs/user/sampler.rst
@@ -10,3 +10,10 @@ Standard usage of ``emcee`` involves instantiating an
 
 .. autoclass:: emcee.EnsembleSampler
    :inherited-members:
+
+Note that several of the :class:`EnsembleSampler` methods return or consume
+:class:`~emcee.state.State` objects:
+
+.. autoclass:: emcee.state.State
+   :inherited-members:
+

--- a/emcee/backends/backend.py
+++ b/emcee/backends/backend.py
@@ -204,7 +204,7 @@ class Backend(object):
         """Save a step to the backend
 
         Args:
-        state (State): The :class:`State` of the ensemble.
+        state (State): The :class:`~emcee.state.State` of the ensemble.
             accepted (ndarray): An array of boolean flags indicating whether
                 or not the proposal for each walker was accepted.
 

--- a/emcee/backends/hdf.py
+++ b/emcee/backends/hdf.py
@@ -170,7 +170,7 @@ class HDFBackend(Backend):
         """Save a step to the backend
 
         Args:
-        state (State): The :class:`State` of the ensemble.
+        state (State): The :class:`~emcee.state.State` of the ensemble.
             accepted (ndarray): An array of boolean flags indicating whether
                 or not the proposal for each walker was accepted.
 

--- a/emcee/ensemble.py
+++ b/emcee/ensemble.py
@@ -187,8 +187,8 @@ class EnsembleSampler(object):
 
         Args:
             initial_state (State or ndarray[nwalkers, ndim]): The initial
-                :class:`State` or positions of the walkers in the parameter
-                space.
+                :class:`~emcee.state.State` or positions of the walkers in the
+                parameter space.
             iterations (Optional[int]): The number of steps to generate.
             tune (Optional[bool]): If ``True``, the parameters of some moves
                 will be automatically tuned.
@@ -208,8 +208,8 @@ class EnsembleSampler(object):
                 ``False``, no progress bar will be shown.
 
 
-        Every ``thin_by`` steps, this generator yields the :class:`State` of
-        the ensemble.
+        Every ``thin_by`` steps, this generator yields the
+        :class:`~emcee.state.State` of the ensemble.
 
         """
         # Interpret the input as a walker state and check the dimensions.

--- a/emcee/state.py
+++ b/emcee/state.py
@@ -8,6 +8,18 @@ import numpy as np
 
 
 class State(object):
+    """An ensemble MCMC sampler
+
+    Args:
+        coords (ndarray[nwalkers, ndim]): The current positions of the walkers
+            in the parameter space.
+        log_prob (ndarray[nwalkers, ndim], Optional): Log posterior
+            probabilities for the  walkers at positions given by ``coords``.
+        blobs (Optional): The metadata “blobs” associated with the current
+            position. The value is only returned if lnpostfn returns blobs too.
+        random_state (Optional): The current state of the random number
+            generator.
+    """
 
     __slots__ = "coords", "log_prob", "blobs", "random_state"
 


### PR DESCRIPTION
This closes #264 by adding a docstring for `State`, including it in the docs, and updating the various references to it to hyperlink to the right place.

@dfm you might want to confirm I got everything about `State` right in the new docstring - it's pretty straightforward but I admit I didn't check if anything there of relevance has changed between emcee 2 and 3...