### PR TITLE
Fix for numpy 1.15

### DIFF
--- a/emcee/ensemble.py
+++ b/emcee/ensemble.py
@@ -406,7 +406,7 @@ class EnsembleSampler(object):
             if len(shape):
                 axes = np.arange(len(shape))[np.array(shape) == 1] + 1
                 if len(axes):
-                    blob = np.squeeze(blob, axes)
+                    blob = np.squeeze(blob, tuple(axes))
 
         # Check for log_prob returning NaN.
         if np.any(np.isnan(log_prob)):


### PR DESCRIPTION
The appveyor failures in #268 piqued my interest even though they were not directly related to that PR.  And it reveals a failure that seems to be due to numpy: it turns out numpy 1.15 (which I can only assume just got picked up by appveyor recently) had a subtle change of behavior: for whatever reason `numpy.squeeze` no longer accepts integer arrays, and that approach is used in processing blobs in `emcee`.  But `squeeze`  seems to behave exactly the same if you just convert the axes argument to tuples...  So this PR just makes that trivial change.

Local testing on 1.15 seemed to do the job.  We shall see what appveyor says, though.