### PR TITLE
MAINT: import from collections.abc

### DIFF
--- a/emcee/ensemble.py
+++ b/emcee/ensemble.py
@@ -4,7 +4,11 @@ from __future__ import division, print_function
 
 __all__ = ["EnsembleSampler"]
 
-from collections.abc import Iterable
+try:
+    from collections.abc import Iterable
+except ImportError:
+    # for py2.7, will be an Exception in 3.8
+    from collections import Iterable
 
 import numpy as np
 

--- a/emcee/ensemble.py
+++ b/emcee/ensemble.py
@@ -4,7 +4,7 @@ from __future__ import division, print_function
 
 __all__ = ["EnsembleSampler"]
 
-from collections import Iterable
+from collections.abc import Iterable
 
 import numpy as np
 


### PR DESCRIPTION
In Py3.8 importing an ABC from `collections` will result in an Exception. In Py3.7 the behaviour is deprecated. This PR addresses the DeprecationWarning. This PR should be applied to the next `emcee` release, as that will be used extensively on Py3.8.

```
DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
```