### PR TITLE
CI: include py37 in travisCI matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,10 @@ matrix:
         - os: linux
           env: PYTHON_VERSION=3.6 NUMPY_VERSION=1.12
 
+        # Linux, Python 3.7
+        - os: linux
+          env: PYTHON_VERSION=3.7 NUMPY_VERSION=1.15
+
         # OSX
         - os: osx
           env: PYTHON_VERSION=2.7 NUMPY_VERSION=1.12


### PR DESCRIPTION
This PR adds a py37 entry to the travisCI matrix. Testing py37 is important for finding issues such as that addressed by #283