### PR TITLE
Fix #289 and modify some tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ install:
   - travis_retry python setup.py develop
 
 script:
-  - py.test -v emcee/tests --cov emcee
+  - pytest -v emcee/tests --cov emcee
 
 after_success:
   - coveralls

--- a/emcee/ensemble.py
+++ b/emcee/ensemble.py
@@ -478,8 +478,8 @@ class EnsembleSampler(object):
     @property
     @deprecated("get_log_prob()")
     def lnprobability(self):  # pragma: no cover
-        return self.get_log_prob()
-
+        log_prob = self.get_log_prob()
+        return np.swapaxes(log_prob, 0, 1)
     @property
     @deprecated("get_log_prob(flat=True)")
     def flatlnprobability(self):  # pragma: no cover

--- a/emcee/tests/unit/test_sampler.py
+++ b/emcee/tests/unit/test_sampler.py
@@ -47,11 +47,15 @@ def test_shapes(backend, moves, nwalkers=32, ndim=3, nsteps=10, seed=1234):
         assert tau.shape == (ndim,)
 
         # Check the shapes.
-        assert sampler.chain.shape == (nwalkers, nsteps, ndim), \
-            "incorrect coordinate dimensions"
+        with pytest.warns(DeprecationWarning):
+            assert sampler.chain.shape == (nwalkers, nsteps, ndim), \
+                "incorrect coordinate dimensions"
+        with pytest.warns(DeprecationWarning):
+            assert sampler.lnprobability.shape == (nwalkers, nsteps), \
+                "incorrect probability dimensions"
         assert sampler.get_chain().shape == (nsteps, nwalkers, ndim), \
             "incorrect coordinate dimensions"
-        assert sampler.lnprobability.shape == (nsteps, nwalkers), \
+        assert sampler.get_log_prob().shape == (nsteps, nwalkers), \
             "incorrect probability dimensions"
 
         assert sampler.acceptance_fraction.shape == (nwalkers,), \
@@ -77,14 +81,14 @@ def test_errors(backend, nwalkers=32, ndim=3, nsteps=5, seed=1234):
 
         # Test for not running.
         with pytest.raises(AttributeError):
-            sampler.chain
+            sampler.get_chain()
         with pytest.raises(AttributeError):
-            sampler.lnprobability
+            sampler.get_log_prob()
 
         # What about not storing the chain.
         sampler.run_mcmc(coords, nsteps, store=False)
         with pytest.raises(AttributeError):
-            sampler.chain
+            sampler.get_chain()
 
         # Now what about if we try to continue using the sampler with an
         # ensemble of a different shape.
@@ -121,12 +125,15 @@ def run_sampler(backend, nwalkers=32, ndim=3, nsteps=25, seed=1234,
 def test_thin(backend):
     with backend() as be:
         with pytest.raises(ValueError):
-            run_sampler(be, thin=-1)
+            with pytest.warns(DeprecationWarning):
+                run_sampler(be, thin=-1)
         with pytest.raises(ValueError):
-            run_sampler(be, thin=0.1)
+            with pytest.warns(DeprecationWarning):
+                run_sampler(be, thin=0.1)
         thinby = 3
         sampler1 = run_sampler(None)
-        sampler2 = run_sampler(be, thin=thinby)
+        with pytest.warns(DeprecationWarning):
+            sampler2 = run_sampler(be, thin=thinby)
         for k in ["get_chain", "get_log_prob"]:
             a = getattr(sampler1, k)()[thinby-1::thinby]
             b = getattr(sampler2, k)()


### PR DESCRIPTION
There was a backwards compatibility problem with `lnprobability` (#289). I fixed it doing exactly the same as in `chain`. 

During testing I realized that the `lnprobability` test actually checked it had the wrong shape (emcee3 like), and there was no test for `get_log_prob` shape. Therefore, I added a test for `get_log_prob` shape. And while I was at it, I used `pytest.warns` to capture and check the deprecation warning of the emcee2 methods present in the tests (here I only modified the already present tests, no addition).

Eventually, I replaced the instance of `logging.warn` by `logging.warning`, which is already present and recommended in 2.7 and therefore should not be a problem for anybody.

EDIT: After seeing the results in travis, I set the strings with latex in it to raw strings to prevent the deprecation warning (the docs still build fine locally), now it should also fix #288.

To sum up: 
* fixes issue with lnprobability shape
 * modified tests to check for deprecation warnings of emcee2 parameters like chain, lnprobability and thin (instead of thin_by)
 * modified logging.warn to logging.warning
 * set strings with latex to raw strings
 * modified .coveragerc to avoid logging.warning now

I hope it helps!