### PR TITLE
Scale-invariant Test for Linear Dependence

### DIFF
--- a/emcee/ensemble.py
+++ b/emcee/ensemble.py
@@ -244,14 +244,9 @@ class EnsembleSampler(object):
         state = State(initial_state, copy=True)
         if np.shape(state.coords) != (self.nwalkers, self.ndim):
             raise ValueError("incompatible input dimensions")
-        if (not skip_initial_state_check) and np.isclose(
-            np.linalg.det(
-                np.cov(state.coords, rowvar=False).reshape(
-                    (self.ndim, self.ndim)
-                )
-            ),
-            0,
-        ):
+        if (not skip_initial_state_check) and np.linalg.cond(
+             np.atleast_2d(np.cov(state.coords, rowvar=False))
+            ) > 1e8:
             warnings.warn(
                 "Initial state is not linearly independent and it will not "
                 "allow a full exploration of parameter space",


### PR DESCRIPTION
At the beginning of `run_mcmc`, the sampler object tests for linear dependence of the initial state.  This pull request computes the condition number of the covariance matrix of the initial state, and compares against `1e8`.  The previous code computed the determinant of the covariance and compared to zero; that method is sensitive to the *scale* of the parameters (i.e. under re-scaling of parameters `x` to `x_prime = A*x`, the determinant scales as `det(cov(x))` to `det(cov(x_prime)) == A**2*det(cov(x))`.  In a parameter space with small parameters, `det(cov(x))` can be close to zero even when the parameters are quite linearly independent, leading to spurious warnings.