### PR TITLE
Quick start ipynb: Text inconsistent with code cell.

### DIFF
--- a/docs/_static/notebooks/quickstart.ipynb
+++ b/docs/_static/notebooks/quickstart.ipynb
@@ -241,7 +241,7 @@
    "metadata": {},
    "source": [
     "You'll notice that I saved the final position of the walkers (after the\n",
-    "100 steps) to a variable called `pos`. You can check out what will be\n",
+    "100 steps) to a variable called `state`. You can check out what will be\n",
     "contained in the other output variables by looking at the documentation for\n",
     "the :func:`EnsembleSampler.run_mcmc` function. The call to the\n",
     ":func:`EnsembleSampler.reset` method clears all of the important bookkeeping\n",


### PR DESCRIPTION
It looks to me as if the variable `run` that is referenced in the test, should really be the variable `state`. Maybe the name has been changed in the past without changing the line of text? (Alternatively, I might just not understand what's going on there and where the variable `run` is supposed to come from.)