### PR TITLE
Add Travis arm64 jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,11 @@ env:
   - NUMPY_VERSION=1.17
   - NUMPY_VERSION=1.16
   - NUMPY_VERSION=1.15
+jobs:
+  include:
+    - python: "3.7"
+      arch: arm64
+      env: NUMPY_VERSION=1.17
 
 install:
   - travis_retry pip install --upgrade pip


### PR DESCRIPTION
On arm64 long double is quadruple precision; in combination with #319 this should avoid surprises. Ideally we would complement this with a test on Windows, where long doubles are plain binary64, the same as doubles.