### PR TITLE
update setup.py to fix building from source

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,7 @@ if __name__ == "__main__":
             ),
             "write_to_template": '__version__ = "{version}"\n',
         },
+        setup_requires=['setuptools_scm'],
         author=find_meta("author"),
         author_email=find_meta("email"),
         maintainer=find_meta("author"),


### PR DESCRIPTION
This commit updates setup.py to add:

    setup(
        ...,
        use_scm_version=...,
        setup_requires=['setuptools_scm'],
        ...,
    )

as recommended by the setuptools-scm project at
https://pypi.org/project/setuptools-scm/.

This commit fixes builds from source which were previously broken due to an ImportError:

    $ git clone https://github.com/dfm/emcee
    $ cd emcee
    $ python setup.py install
    $ cd ~
    $ python
    $ import emcee
    ImportError: No module named emcee_version

This should fix issue #321.