### PR TITLE
V2.2.x

### DIFF
--- a/emcee/sampler.py
+++ b/emcee/sampler.py
@@ -65,6 +65,11 @@ class Sampler(object):
         if it doesn't work. Don't say I didn't warn you...
 
         """
+        if isinstance(state, (np.random.mtrand.RandomState,
+                              np.random.RandomState)):
+            # The user provided the state object instead of the state info
+            state = state.get_state()
+
         try:
             self._random.set_state(state)
         except:

--- a/emcee/sampler.py
+++ b/emcee/sampler.py
@@ -164,7 +164,7 @@ class Sampler(object):
                                  "been called.")
             pos0 = self._last_run_mcmc_result[0]
             if lnprob0 is None:
-                rstate0 = self._last_run_mcmc_result[1]
+                lnprob0 = self._last_run_mcmc_result[1]
             if rstate0 is None:
                 rstate0 = self._last_run_mcmc_result[2]
 

--- a/emcee/tests.py
+++ b/emcee/tests.py
@@ -282,3 +282,20 @@ class Tests:
         # None is given and that it records whatever it does
         s.run_mcmc(None, N=self.N)
         assert s.chain.shape[1] == 2 * self.N
+
+    def test_deterministic(self):
+        self.sampler = s = EnsembleSampler(self.nwalkers, self.ndim,
+                                           lnprob_gaussian, args=[self.icov])
+
+        # Normal usage
+        rstate0 = s.random_state
+        p1, lnprob1 = s.run_mcmc(self.p0, self.N)[:2]
+        p2, lnprob2 = s.run_mcmc(self.p0, self.N, rstate0=rstate0)[:2]
+        assert np.all(p1 == p2) and np.all(lnprob1 == lnprob2)
+
+        # Using the RandomState() object directly
+        rstate_obj = np.random.mtrand.RandomState()
+        rstate_obj.set_state(rstate0)
+        p3, lnprob3 = s.run_mcmc(self.p0, self.N, rstate0=rstate_obj)[:2]
+        assert np.all(p1 == p3) and np.all(lnprob1 == lnprob3), \
+           "Failed to set state from np.mtrand.RandomState object"


### PR DESCRIPTION
This addresses issues #300 and #313, including the suppression of direct references to np.random. 
It also adds a new test case  `test_deterministic` to demonstrate that re-running `run_mcmc` with the same random state produces the exact same output.