### PR TITLE
Add seed argument to EnsembleSampler

### DIFF
--- a/src/emcee/ensemble.py
+++ b/src/emcee/ensemble.py
@@ -58,6 +58,7 @@ class EnsembleSampler(object):
             to accept a list of position vectors instead of just one. Note
             that ``pool`` will be ignored if this is ``True``.
             (default: ``False``)
+        seed (Optional[int]): Seed for the random number generator.
 
     """
 
@@ -73,6 +74,7 @@ class EnsembleSampler(object):
         backend=None,
         vectorize=False,
         blobs_dtype=None,
+        seed=None,
         # Deprecated...
         a=None,
         postargs=None,
@@ -149,6 +151,8 @@ class EnsembleSampler(object):
         # of without affecting the numpy-wide generator
         self._random = np.random.mtrand.RandomState()
         self._random.set_state(state)
+        if seed is not None:
+            self._random.seed(seed)
 
         # Do a little bit of _magic_ to make the likelihood call with
         # ``args`` and ``kwargs`` pickleable.

--- a/src/emcee/tests/unit/test_sampler.py
+++ b/src/emcee/tests/unit/test_sampler.py
@@ -137,7 +137,8 @@ def run_sampler(
 ):
     np.random.seed(seed)
     coords = np.random.randn(nwalkers, ndim)
-    sampler = EnsembleSampler(nwalkers, ndim, normal_log_prob, backend=backend)
+    np.random.seed(None)
+    sampler = EnsembleSampler(nwalkers, ndim, normal_log_prob, backend=backend, seed=seed)
     sampler.run_mcmc(
         coords,
         nsteps,
@@ -319,3 +320,25 @@ def test_walkers_independent_randn_offset_longdouble(nwalkers, ndim, offset):
         np.random.randn(nwalkers, ndim)
         + np.ones((nwalkers, ndim), dtype=np.longdouble) * offset
     )
+
+
+def test_sampler_seed():
+    nwalkers=32
+    ndim=3
+    nsteps=25
+    np.random.seed(456)
+    coords = np.random.randn(nwalkers, ndim)
+    sampler1 = EnsembleSampler(nwalkers, ndim, normal_log_prob, seed=1234)
+    sampler2 = EnsembleSampler(nwalkers, ndim, normal_log_prob, seed=2234)
+    sampler3 = EnsembleSampler(nwalkers, ndim, normal_log_prob, seed=1234)
+    for sampler in (sampler1, sampler2, sampler3):
+        sampler.run_mcmc(
+            coords,
+            nsteps,
+        )
+    for k in ["get_chain", "get_log_prob"]:
+        a = getattr(sampler1, k)()
+        b = getattr(sampler2, k)()
+        c = getattr(sampler3, k)()
+        assert not np.allclose(a, b), "inconsistent {0}".format(k)
+        assert np.allclose(a, c), "inconsistent {0}".format(k)

--- a/src/emcee/tests/unit/test_sampler.py
+++ b/src/emcee/tests/unit/test_sampler.py
@@ -138,7 +138,9 @@ def run_sampler(
     np.random.seed(seed)
     coords = np.random.randn(nwalkers, ndim)
     np.random.seed(None)
-    sampler = EnsembleSampler(nwalkers, ndim, normal_log_prob, backend=backend, seed=seed)
+    sampler = EnsembleSampler(
+        nwalkers, ndim, normal_log_prob, backend=backend, seed=seed
+    )
     sampler.run_mcmc(
         coords,
         nsteps,
@@ -323,19 +325,16 @@ def test_walkers_independent_randn_offset_longdouble(nwalkers, ndim, offset):
 
 
 def test_sampler_seed():
-    nwalkers=32
-    ndim=3
-    nsteps=25
+    nwalkers = 32
+    ndim = 3
+    nsteps = 25
     np.random.seed(456)
     coords = np.random.randn(nwalkers, ndim)
     sampler1 = EnsembleSampler(nwalkers, ndim, normal_log_prob, seed=1234)
     sampler2 = EnsembleSampler(nwalkers, ndim, normal_log_prob, seed=2234)
     sampler3 = EnsembleSampler(nwalkers, ndim, normal_log_prob, seed=1234)
     for sampler in (sampler1, sampler2, sampler3):
-        sampler.run_mcmc(
-            coords,
-            nsteps,
-        )
+        sampler.run_mcmc(coords, nsteps)
     for k in ["get_chain", "get_log_prob"]:
         a = getattr(sampler1, k)()
         b = getattr(sampler2, k)()


### PR DESCRIPTION
I saw this come up on the mailing list and had some time for this. I hope it helps.

This PR adds `seed` as a new argument to `EnsembleSampler` with default value `None`. Also, with `seed=None` the random state is not reseeded but instead it is left as is so that calling `np.random.seed()` before creating the sampler still works the same way. It also adds a test to check that the `seed` argument "overwrites" `np.random.seed`.