### PR TITLE
Fix long double test failures with HDF5 and ppc64el

### DIFF
--- a/src/emcee/backends/hdf.py
+++ b/src/emcee/backends/hdf.py
@@ -2,7 +2,7 @@
 
 from __future__ import division, print_function
 
-__all__ = ["HDFBackend", "TempHDFBackend", "HDF5_SUPPORTS_LONGDOUBLE"]
+__all__ = ["HDFBackend", "TempHDFBackend", "does_hdf5_support_longdouble"]
 
 import os
 from tempfile import NamedTemporaryFile
@@ -36,9 +36,6 @@ def does_hdf5_support_longdouble():
             if hf["group"]["data"].dtype != np.longdouble:
                 return False
     return True
-
-
-HDF5_SUPPORTS_LONGDOUBLE = does_hdf5_support_longdouble()
 
 
 class HDFBackend(Backend):

--- a/src/emcee/backends/hdf.py
+++ b/src/emcee/backends/hdf.py
@@ -2,7 +2,7 @@
 
 from __future__ import division, print_function
 
-__all__ = ["HDFBackend", "TempHDFBackend"]
+__all__ = ["HDFBackend", "TempHDFBackend", "HDF5_SUPPORTS_LONGDOUBLE"]
 
 import os
 from tempfile import NamedTemporaryFile
@@ -17,6 +17,28 @@ try:
     import h5py
 except ImportError:
     h5py = None
+
+
+def does_hdf5_support_longdouble():
+    if h5py is None:
+        return False
+    with NamedTemporaryFile(prefix="emcee-temporary-hdf5",
+                            suffix=".hdf5",
+                            delete=False) as f:
+        f.close()
+
+        with h5py.File(f.name, "w") as hf:
+            g = hf.create_group("group")
+            g.create_dataset("data", data=np.ones(1, dtype=np.longdouble))
+            if g["data"].dtype != np.longdouble:
+                return False
+        with h5py.File(f.name, "r") as hf:
+            if hf["group"]["data"].dtype != np.longdouble:
+                return False
+    return True
+
+
+HDF5_SUPPORTS_LONGDOUBLE = does_hdf5_support_longdouble()
 
 
 class HDFBackend(Backend):

--- a/src/emcee/tests/integration/test_longdouble.py
+++ b/src/emcee/tests/integration/test_longdouble.py
@@ -2,7 +2,7 @@ import numpy as np
 import pytest
 
 import emcee
-from emcee.backends.hdf import HDF5_SUPPORTS_LONGDOUBLE, TempHDFBackend
+from emcee.backends.hdf import does_hdf5_support_longdouble, TempHDFBackend
 
 
 def test_longdouble_doesnt_crash_bug_312():
@@ -21,7 +21,7 @@ def test_longdouble_doesnt_crash_bug_312():
 @pytest.mark.parametrize("cls", emcee.backends.get_test_backends())
 def test_longdouble_actually_needed(cls):
     if (issubclass(cls, TempHDFBackend)
-            and not HDF5_SUPPORTS_LONGDOUBLE):
+            and not does_hdf5_support_longdouble()):
         pytest.xfail("HDF5 does not support long double on this platform")
 
     mjd = np.longdouble(58000.)

--- a/src/emcee/tests/integration/test_longdouble.py
+++ b/src/emcee/tests/integration/test_longdouble.py
@@ -2,6 +2,7 @@ import numpy as np
 import pytest
 
 import emcee
+from emcee.backends.hdf import HDF5_SUPPORTS_LONGDOUBLE, TempHDFBackend
 
 
 def test_longdouble_doesnt_crash_bug_312():
@@ -17,9 +18,11 @@ def test_longdouble_doesnt_crash_bug_312():
     sampler.run_mcmc(p0, 100)
 
 
-@pytest.mark.parametrize("cls", [emcee.backends.Backend,
-                                 emcee.backends.TempHDFBackend])
+@pytest.mark.parametrize("cls", emcee.backends.get_test_backends())
 def test_longdouble_actually_needed(cls):
+    if (issubclass(cls, TempHDFBackend)
+            and not HDF5_SUPPORTS_LONGDOUBLE):
+        pytest.xfail("HDF5 does not support long double on this platform")
 
     mjd = np.longdouble(58000.)
     sigma = 100*np.finfo(np.longdouble).eps*mjd

--- a/src/emcee/tests/unit/test_backends.py
+++ b/src/emcee/tests/unit/test_backends.py
@@ -8,7 +8,7 @@ import numpy as np
 import pytest
 
 from emcee import EnsembleSampler, backends, State
-from emcee.backends.hdf import HDF5_SUPPORTS_LONGDOUBLE
+from emcee.backends.hdf import does_hdf5_support_longdouble
 
 try:
     import h5py
@@ -236,7 +236,7 @@ def test_multi_hdf5():
 @pytest.mark.parametrize("backend", all_backends)
 def test_longdouble_preserved(backend):
     if (issubclass(backend, backends.TempHDFBackend)
-            and not HDF5_SUPPORTS_LONGDOUBLE):
+            and not does_hdf5_support_longdouble()):
         pytest.xfail("HDF5 does not support long double on this platform")
     nwalkers = 10
     ndim = 2

--- a/src/emcee/tests/unit/test_backends.py
+++ b/src/emcee/tests/unit/test_backends.py
@@ -2,12 +2,18 @@
 
 import os
 from itertools import product
+from tempfile import NamedTemporaryFile
 
-import h5py
 import numpy as np
 import pytest
 
 from emcee import EnsembleSampler, backends, State
+from emcee.backends.hdf import HDF5_SUPPORTS_LONGDOUBLE
+
+try:
+    import h5py
+except ImportError:
+    h5py = None
 
 __all__ = ["test_backend", "test_reload"]
 
@@ -55,6 +61,7 @@ def _custom_allclose(a, b):
             assert np.allclose(a[n], b[n])
 
 
+@pytest.mark.skipif(h5py is None, reason="HDF5 not available")
 def test_uninit(tmpdir):
     fn = str(tmpdir.join("EMCEE_TEST_FILE_DO_NOT_USE.h5"))
     if os.path.exists(fn):
@@ -208,6 +215,7 @@ def test_restart(backend, dtype):
         assert np.allclose(a, b), "inconsistent acceptance fraction"
 
 
+@pytest.mark.skipif(h5py is None, reason="HDF5 not available")
 def test_multi_hdf5():
     with backends.TempHDFBackend() as backend1:
         run_sampler(backend1)
@@ -227,6 +235,9 @@ def test_multi_hdf5():
 
 @pytest.mark.parametrize("backend", all_backends)
 def test_longdouble_preserved(backend):
+    if (issubclass(backend, backends.TempHDFBackend)
+            and not HDF5_SUPPORTS_LONGDOUBLE):
+        pytest.xfail("HDF5 does not support long double on this platform")
     nwalkers = 10
     ndim = 2
     nsteps = 5
@@ -252,15 +263,3 @@ def test_longdouble_preserved(backend):
 
             assert s.log_prob.dtype == np.longdouble
             assert np.all(s.log_prob == lp)
-
-
-def test_hdf5_dtypes():
-    nwalkers = 10
-    ndim = 2
-    with backends.TempHDFBackend(dtype=np.longdouble) as b:
-        assert b.dtype == np.longdouble
-        b.reset(nwalkers, ndim)
-        b.grow(1, None)
-        with h5py.File(b.filename, "r") as f:
-            g = f["test"]
-            assert g["chain"].dtype == np.longdouble

--- a/src/emcee/tests/unit/test_backends.py
+++ b/src/emcee/tests/unit/test_backends.py
@@ -260,6 +260,7 @@ def test_hdf5_dtypes():
     with backends.TempHDFBackend(dtype=np.longdouble) as b:
         assert b.dtype == np.longdouble
         b.reset(nwalkers, ndim)
+        b.grow(1, None)
         with h5py.File(b.filename, "r") as f:
             g = f["test"]
             assert g["chain"].dtype == np.longdouble


### PR DESCRIPTION
Detects whether HDF5 supports long doubles and `xfail`s tests if it doesn't.

Closes #353 