### PR TITLE
Add python3.8 environment to tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{36,37}
+envlist = py{36,37,38}
 
 [testenv]
 description = Unit tests


### PR DESCRIPTION
Currently I can't actually run `tox` because my machine only has python3.8 installed. This PR just adds a python3.8 environment to the tox list; all tests pass fine.