### PR TITLE
Add HDF5 compression

### DIFF
--- a/src/emcee/backends/hdf.py
+++ b/src/emcee/backends/hdf.py
@@ -22,9 +22,9 @@ except ImportError:
 def does_hdf5_support_longdouble():
     if h5py is None:
         return False
-    with NamedTemporaryFile(prefix="emcee-temporary-hdf5",
-                            suffix=".hdf5",
-                            delete=False) as f:
+    with NamedTemporaryFile(
+        prefix="emcee-temporary-hdf5", suffix=".hdf5", delete=False
+    ) as f:
         f.close()
 
         with h5py.File(f.name, "w") as hf:
@@ -53,12 +53,23 @@ class HDFBackend(Backend):
             ``RuntimeError`` if the file is opened with write access.
 
     """
-    def __init__(self, filename, name="mcmc", read_only=False, dtype=None):
+
+    def __init__(
+        self,
+        filename,
+        name="mcmc",
+        read_only=False,
+        dtype=None,
+        compression=None,
+        compression_opts=None,
+    ):
         if h5py is None:
             raise ImportError("you must install 'h5py' to use the HDFBackend")
         self.filename = filename
         self.name = name
         self.read_only = read_only
+        self.compression = compression
+        self.compression_opts = compression_opts
         if dtype is None:
             self.dtype_set = False
             self.dtype = np.float64
@@ -109,18 +120,27 @@ class HDFBackend(Backend):
             g.attrs["ndim"] = ndim
             g.attrs["has_blobs"] = False
             g.attrs["iteration"] = 0
-            g.create_dataset("accepted", data=np.zeros(nwalkers))
+            g.create_dataset(
+                "accepted",
+                data=np.zeros(nwalkers),
+                compression=self.compression,
+                compression_opts=self.compression_opts,
+            )
             g.create_dataset(
                 "chain",
                 (0, nwalkers, ndim),
                 maxshape=(None, nwalkers, ndim),
                 dtype=self.dtype,
+                compression=self.compression,
+                compression_opts=self.compression_opts,
             )
             g.create_dataset(
                 "log_prob",
                 (0, nwalkers),
                 maxshape=(None, nwalkers),
                 dtype=self.dtype,
+                compression=self.compression,
+                compression_opts=self.compression_opts,
             )
 
     def has_blobs(self):
@@ -206,6 +226,8 @@ class HDFBackend(Backend):
                         (ntot, nwalkers),
                         maxshape=(None, nwalkers),
                         dtype=dt,
+                        compression=self.compression,
+                        compression_opts=self.compression_opts,
                     )
                 else:
                     g["blobs"].resize(ntot, axis=0)
@@ -239,18 +261,25 @@ class HDFBackend(Backend):
 
 
 class TempHDFBackend(object):
-
-    def __init__(self, dtype=None):
+    def __init__(self, dtype=None, compression=None, compression_opts=None):
         self.dtype = dtype
         self.filename = None
+        self.compression = compression
+        self.compression_opts = compression_opts
 
     def __enter__(self):
-        f = NamedTemporaryFile(prefix="emcee-temporary-hdf5",
-                               suffix=".hdf5",
-                               delete=False)
+        f = NamedTemporaryFile(
+            prefix="emcee-temporary-hdf5", suffix=".hdf5", delete=False
+        )
         f.close()
         self.filename = f.name
-        return HDFBackend(f.name, "test", dtype=self.dtype)
+        return HDFBackend(
+            f.name,
+            "test",
+            dtype=self.dtype,
+            compression=self.compression,
+            compression_opts=self.compression_opts,
+        )
 
     def __exit__(self, exception_type, exception_value, traceback):
         os.remove(self.filename)

--- a/src/emcee/tests/unit/test_backends.py
+++ b/src/emcee/tests/unit/test_backends.py
@@ -3,7 +3,6 @@
 import os
 from os.path import join
 from itertools import product
-from tempfile import TemporaryDirectory
 
 import numpy as np
 import pytest

--- a/src/emcee/tests/unit/test_backends.py
+++ b/src/emcee/tests/unit/test_backends.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
 
 import os
+from os.path import join
 from itertools import product
-from tempfile import NamedTemporaryFile
+from tempfile import TemporaryDirectory
 
 import numpy as np
 import pytest
@@ -263,3 +264,14 @@ def test_longdouble_preserved(backend):
 
             assert s.log_prob.dtype == np.longdouble
             assert np.all(s.log_prob == lp)
+
+
+@pytest.mark.skipif(h5py is None, reason="HDF5 not available")
+def test_hdf5_compression():
+    with backends.TempHDFBackend(compression="gzip") as b:
+        run_sampler(b, blobs=True)
+        # re-open and read
+        b.get_chain()
+        b.get_blobs()
+        b.get_log_prob()
+        b.accepted


### PR DESCRIPTION
Allow users to enable compression on HDF5 backends.

Compression is applied uniformly to all datasets; one might expect different compression for `accepted` than `chain` or `blobs` but the interface doesn't need additional complications. If `reset` is used on an existing HDF5 file the newly created datasets will have compression enabled or not as specified during backend creation.

Closes #338 