### PR TITLE
Solidify blobs dtype inference

### DIFF
--- a/src/emcee/backends/backend.py
+++ b/src/emcee/backends/backend.py
@@ -166,7 +166,7 @@ class Backend(object):
 
         Args:
             ngrow (int): The number of steps to grow the chain.
-            blobs: The current list of blobs. This is used to compute the
+            blobs: The current array of blobs. This is used to compute the
                 dtype for the blobs array.
 
         """
@@ -177,7 +177,7 @@ class Backend(object):
         a = np.empty((i, self.nwalkers), dtype=self.dtype)
         self.log_prob = np.concatenate((self.log_prob, a), axis=0)
         if blobs is not None:
-            dt = np.dtype((blobs[0].dtype, blobs[0].shape))
+            dt = np.dtype((blobs.dtype, blobs.shape[1:]))
             a = np.empty((i, self.nwalkers), dtype=dt)
             if self.blobs is None:
                 self.blobs = a

--- a/src/emcee/backends/hdf.py
+++ b/src/emcee/backends/hdf.py
@@ -209,11 +209,11 @@ class HDFBackend(Backend):
                     )
                 else:
                     g["blobs"].resize(ntot, axis=0)
-                    if g["blobs"].shape[1:] != blobs.shape[1:]:
+                    if g["blobs"].dtype.shape != blobs.shape[1:]:
                         raise ValueError(
                             "Existing blobs have shape {} but new blobs "
                             "requested with shape {}"
-                            .format(g["blobs"].shape[1:], blobs.shape[1:]))
+                            .format(g["blobs"].dtype.shape, blobs.shape[1:]))
                 g.attrs["has_blobs"] = True
 
     def save_step(self, state, accepted):

--- a/src/emcee/backends/hdf.py
+++ b/src/emcee/backends/hdf.py
@@ -185,7 +185,7 @@ class HDFBackend(Backend):
 
         Args:
             ngrow (int): The number of steps to grow the chain.
-            blobs: The current list of blobs. This is used to compute the
+            blobs: The current array of blobs. This is used to compute the
                 dtype for the blobs array.
 
         """
@@ -200,7 +200,7 @@ class HDFBackend(Backend):
                 has_blobs = g.attrs["has_blobs"]
                 if not has_blobs:
                     nwalkers = g.attrs["nwalkers"]
-                    dt = np.dtype((blobs[0].dtype, blobs[0].shape))
+                    dt = np.dtype((blobs.dtype, blobs.shape[1:]))
                     g.create_dataset(
                         "blobs",
                         (ntot, nwalkers),
@@ -209,6 +209,11 @@ class HDFBackend(Backend):
                     )
                 else:
                     g["blobs"].resize(ntot, axis=0)
+                    if g["blobs"].shape[1:] != blobs.shape[1:]:
+                        raise ValueError(
+                            "Existing blobs have shape {} but new blobs "
+                            "requested with shape {}"
+                            .format(g["blobs"].shape[1:], blobs.shape[1:]))
                 g.attrs["has_blobs"] = True
 
     def save_step(self, state, accepted):

--- a/src/emcee/ensemble.py
+++ b/src/emcee/ensemble.py
@@ -442,6 +442,9 @@ class EnsembleSampler(object):
                     dt = np.atleast_1d(blob[0]).dtype
                 except ValueError:
                     dt = np.dtype("object")
+                if dt.kind in "US":
+                    # Strings need to be object arrays or we risk truncation
+                    dt = np.dtype("object")
             blob = np.array(blob, dtype=dt)
 
             # Deal with single blobs properly

--- a/src/emcee/ensemble.py
+++ b/src/emcee/ensemble.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 
+import warnings
+
 import numpy as np
 
 from .backends import Backend
@@ -439,7 +441,20 @@ class EnsembleSampler(object):
                 dt = self.blobs_dtype
             else:
                 try:
-                    dt = np.atleast_1d(blob[0]).dtype
+                    with warnings.catch_warnings(record=True):
+                        warnings.simplefilter("error",
+                                              np.VisibleDeprecationWarning)
+                        try:
+                            dt = np.atleast_1d(blob[0]).dtype
+                        except Warning:
+                            deprecation_warning(
+                                "You have provided blobs that are not all the "
+                                "same shape or size. This means they must be "
+                                "placed in an object array. Numpy has "
+                                "deprecated this automatic detection, so "
+                                "please specify "
+                                "blobs_dtype=np.dtype('object')")
+                            dt = np.dtype("object")
                 except ValueError:
                     dt = np.dtype("object")
                 if dt.kind in "US":

--- a/src/emcee/tests/unit/test_blobs.py
+++ b/src/emcee/tests/unit/test_blobs.py
@@ -51,7 +51,7 @@ def test_blob_shape(backend, blob_spec):
 
         if ragged:
             with warnings.catch_warnings():
-                warnings.simplefilter("ignore", np.VisibleDeprecationWarning)
+                warnings.simplefilter("ignore", DeprecationWarning)
                 sampler.run_mcmc(coords, nsteps)
         else:
             sampler.run_mcmc(coords, nsteps)

--- a/src/emcee/tests/unit/test_blobs.py
+++ b/src/emcee/tests/unit/test_blobs.py
@@ -22,8 +22,9 @@ class BlobLogProb(object):
 @pytest.mark.parametrize(
     "blob_spec",
     [
-        (True, False, (5, 3), lambda x: np.random.randn(5, 3)),
         (True, False, 5, lambda x: np.random.randn(5)),
+        (True, False, (5, 3), lambda x: np.random.randn(5, 3)),
+        (True, False, (5, 3), lambda x: np.random.randn(1, 5, 1, 3, 1)),
         (True, False, 0, lambda x: np.random.randn()),
         (False, True, 2, lambda x: (1.0, np.random.randn(3))),
         (False, False, 0, lambda x: "face"),

--- a/src/emcee/tests/unit/test_blobs.py
+++ b/src/emcee/tests/unit/test_blobs.py
@@ -50,7 +50,8 @@ def test_blob_shape(backend, blob_spec):
         nsteps = 10
 
         if ragged:
-            with pytest.warns(np.VisibleDeprecationWarning):
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", np.VisibleDeprecationWarning)
                 sampler.run_mcmc(coords, nsteps)
         else:
             sampler.run_mcmc(coords, nsteps)

--- a/src/emcee/tests/unit/test_blobs.py
+++ b/src/emcee/tests/unit/test_blobs.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 
+import warnings
+
 import numpy as np
 import pytest
 
@@ -20,32 +22,73 @@ class BlobLogProb(object):
 @pytest.mark.parametrize(
     "blob_spec",
     [
-        (True, 5, lambda x: np.random.randn(5)),
-        (True, 0, lambda x: np.random.randn()),
-        (False, 2, lambda x: (1.0, np.random.randn(3))),
-        (False, 0, lambda x: "face"),
-        (False, 2, lambda x: (np.random.randn(5), "face")),
+        (True, False, (5, 3), lambda x: np.random.randn(5, 3)),
+        (True, False, 5, lambda x: np.random.randn(5)),
+        (True, False, 0, lambda x: np.random.randn()),
+        (False, True, 2, lambda x: (1.0, np.random.randn(3))),
+        (False, False, 0, lambda x: "face"),
+        (False, False, 0, lambda x: object()),
+        (False, False, 2, lambda x: ("face", "surface")),
+        (False, True, 2, lambda x: (np.random.randn(5), "face")),
     ],
 )
 def test_blob_shape(backend, blob_spec):
     # HDF backends don't support the object type
-    if backend in (backends.TempHDFBackend,) and not blob_spec[0]:
+    hdf_able, ragged, blob_shape, func = blob_spec
+    if backend in (backends.TempHDFBackend,) and not hdf_able:
         return
 
     with backend() as be:
         np.random.seed(42)
 
-        model = BlobLogProb(blob_spec[2])
+        model = BlobLogProb(func)
         coords = np.random.randn(32, 3)
         nwalkers, ndim = coords.shape
 
         sampler = EnsembleSampler(nwalkers, ndim, model, backend=be)
         nsteps = 10
 
-        sampler.run_mcmc(coords, nsteps)
+        if ragged:
+            with pytest.warns(np.VisibleDeprecationWarning):
+                sampler.run_mcmc(coords, nsteps)
+        else:
+            sampler.run_mcmc(coords, nsteps)
 
         shape = [nsteps, nwalkers]
-        if blob_spec[1] > 0:
-            shape += [blob_spec[1]]
+        if isinstance(blob_shape, tuple):
+            shape += blob_shape
+        elif blob_shape > 0:
+            shape += [blob_shape]
 
         assert sampler.get_blobs().shape == tuple(shape)
+        if not hdf_able:
+            assert sampler.get_blobs().dtype == np.dtype("object")
+
+
+class VariableLogProb:
+    def __init__(self):
+        self.i = 3
+
+    def __call__(self, *args):
+        return 0, np.zeros(self.i)
+
+
+@pytest.mark.parametrize("backend", backends.get_test_backends())
+def test_blob_mismatch(backend):
+    with backend() as be:
+        np.random.seed(42)
+
+        model = VariableLogProb()
+        coords = np.random.randn(32, 3)
+        nwalkers, ndim = coords.shape
+
+        sampler = EnsembleSampler(nwalkers, ndim, model, backend=be)
+
+        model.i += 1
+        # We don't save blobs from the initial points
+        # so blob shapes are taken from the first round of moves
+        sampler.run_mcmc(coords, 1)
+
+        model.i += 1
+        with pytest.raises(ValueError):
+            sampler.run_mcmc(coords, 1)


### PR DESCRIPTION
Reduce the chance of user surprise due to blob dtype inference - strings are object dtypes, object dtypes don't lead to backend weirdness, ragged blob dtypes raise `numpy.VisibleDeprecationWarning` unless `blobs_dtype` is specified. Also fixes problems where `grow` used to re-infer blob dtypes. 

Closes #361 