### PR TITLE
Added infinite iterations option to EnsembleSampler.sample

### DIFF
--- a/src/emcee/ensemble.py
+++ b/src/emcee/ensemble.py
@@ -247,7 +247,7 @@ class EnsembleSampler(object):
         :class:`State` of the ensemble.
 
         """
-        if iterations is None and not store is False:
+        if iterations is None and store:
             raise ValueError("'store' must be False when 'iterations' is None")
         # Interpret the input as a walker state and check the dimensions.
         state = State(initial_state, copy=True)

--- a/src/emcee/ensemble.py
+++ b/src/emcee/ensemble.py
@@ -3,6 +3,7 @@
 import warnings
 
 import numpy as np
+from itertools import count
 
 from .backends import Backend
 from .model import Model
@@ -218,7 +219,8 @@ class EnsembleSampler(object):
             initial_state (State or ndarray[nwalkers, ndim]): The initial
                 :class:`State` or positions of the walkers in the
                 parameter space.
-            iterations (Optional[int]): The number of steps to generate.
+            iterations (Optional[int or NoneType]): The number of steps to generate.
+                ``None`` generates an infinite stream (requires ``store=False``).
             tune (Optional[bool]): If ``True``, the parameters of some moves
                 will be automatically tuned.
             thin_by (Optional[int]): If you only want to store and yield every
@@ -245,6 +247,8 @@ class EnsembleSampler(object):
         :class:`State` of the ensemble.
 
         """
+        if iterations is None and not store is False:
+            raise ValueError("'store' must be False when 'iterations' is None")
         # Interpret the input as a walker state and check the dimensions.
         state = State(initial_state, copy=True)
         if np.shape(state.coords) != (self.nwalkers, self.ndim):
@@ -306,7 +310,6 @@ class EnsembleSampler(object):
 
             yield_step = 1
             checkpoint_step = thin
-            iterations = int(iterations)
             if store:
                 nsaves = iterations // checkpoint_step
                 self.backend.grow(nsaves, state.blobs)
@@ -319,7 +322,6 @@ class EnsembleSampler(object):
 
             yield_step = thin_by
             checkpoint_step = thin_by
-            iterations = int(iterations)
             if store:
                 self.backend.grow(iterations, state.blobs)
 
@@ -333,10 +335,10 @@ class EnsembleSampler(object):
         )
 
         # Inject the progress bar
-        total = iterations * yield_step
+        total = None if iterations is None else iterations * yield_step
         with get_progress_bar(progress, total) as pbar:
             i = 0
-            for _ in range(iterations):
+            for _ in count() if iterations is None else range(iterations):
                 for _ in range(yield_step):
                     # Choose a random move
                     move = self._random.choice(self._moves, p=self._weights)

--- a/src/emcee/tests/unit/test_sampler.py
+++ b/src/emcee/tests/unit/test_sampler.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import pickle
-from itertools import product
+from itertools import product, islice
 
 import numpy as np
 import pytest
@@ -319,3 +319,17 @@ def test_walkers_independent_randn_offset_longdouble(nwalkers, ndim, offset):
         np.random.randn(nwalkers, ndim)
         + np.ones((nwalkers, ndim), dtype=np.longdouble) * offset
     )
+
+@pytest.mark.parametrize("backend", all_backends)
+def test_infinite_iterations_store(backend, nwalkers=32, ndim=3):
+    with backend() as be:
+        coords = np.random.randn(nwalkers, ndim)
+        with pytest.raises(ValueError):
+            next(EnsembleSampler(nwalkers, ndim, normal_log_prob, backend=be).sample(coords, iterations=None, store=True))
+
+@pytest.mark.parametrize("backend", all_backends)
+def test_infinite_iterations(backend, nwalkers=32, ndim=3):
+    with backend() as be:
+        coords = np.random.randn(nwalkers, ndim)
+        for state in islice(EnsembleSampler(nwalkers, ndim, normal_log_prob, backend=be).sample(coords, iterations=None, store=False), 10):
+            pass


### PR DESCRIPTION
Added option to use `iterations=None` in [`EnsembleSampler.sample`](https://emcee.readthedocs.io/en/stable/user/sampler/#emcee.EnsembleSampler.sample), as discussed in #369. This produces an infinite stream of samples. Requires `store=False`. Note that tqdm can handle `total=None`. Example:

```python3
import numpy as np
from emcee import EnsembleSampler

def logp(x):
    return np.where(((0 <= x) & (x <= 1)).all(-1), 0, -np.inf)

x = np.random.rand(10, 2)

for state in EnsembleSampler(*x.shape, logp).sample(x, progress=True, iterations=None, store=False):
    pass
```