### PR TITLE
Fix np.float deprecation

### DIFF
--- a/src/emcee/backends/backend.py
+++ b/src/emcee/backends/backend.py
@@ -14,7 +14,7 @@ class Backend(object):
     def __init__(self, dtype=None):
         self.initialized = False
         if dtype is None:
-            dtype = np.float
+            dtype = np.float64
         self.dtype = dtype
 
     def reset(self, nwalkers, ndim):


### PR DESCRIPTION
`np.float` is deprecated as of numpy 1.20. https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations.