### PR TITLE
Support for named parameters

### DIFF
--- a/src/emcee/ensemble.py
+++ b/src/emcee/ensemble.py
@@ -168,23 +168,28 @@ class EnsembleSampler(object):
         self.params_are_named: bool = parameter_names is not None
         self.parameter_names: Optional[List[str]] = parameter_names
         if self.params_are_named:
+            assert isinstance(parameter_names, (list, dict))
+
             # Don't support vectorizing yet
             msg = "named parameters with vectorization unsupported for now"
             assert not self.vectorize, msg
-            
-            # Check for all named
-            msg = "name all parameters or set `parameter_names` to `None`"
-            assert len(parameter_names) == ndim, msg
 
-            # Check for duplicate names
-            dupes = set()
-            uniq = []
-            for name in parameter_names:
-                if name not in dupes:
-                    uniq.append(name)
-                    dupes.add(name)
-            msg = f"duplicate paramters: {dupes}"
-            assert len(uniq) == len(parameter_names), msg
+            if isinstance(parameter_names, list):
+                # Check for all named
+                msg = "name all parameters or set `parameter_names` to `None`"
+                assert len(parameter_names) == ndim, msg
+
+                # Check for duplicate names
+                dupes = set()
+                uniq = []
+                for name in parameter_names:
+                    if name not in dupes:
+                        uniq.append(name)
+                        dupes.add(name)
+                msg = f"duplicate paramters: {dupes}"
+                assert len(uniq) == len(parameter_names), msg
+            else:
+                pass  # TODO
 
     @property
     def random_state(self):

--- a/src/emcee/ensemble.py
+++ b/src/emcee/ensemble.py
@@ -2,7 +2,7 @@
 
 import warnings
 
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Union
 
 import numpy as np
 from itertools import count
@@ -63,6 +63,10 @@ class EnsembleSampler(object):
             to accept a list of position vectors instead of just one. Note
             that ``pool`` will be ignored if this is ``True``.
             (default: ``False``)
+        parameter_names (Optional[Union[List[str], Dict[str, List[int]]]]):
+            names of individual parameters or groups of parameters. If
+            specified, the ``log_prob_fn`` will recieve a dictionary of
+            parameters, rather than a ``np.ndarray``.
 
     """
 
@@ -78,7 +82,7 @@ class EnsembleSampler(object):
         backend=None,
         vectorize=False,
         blobs_dtype=None,
-        parameter_names: Optional[List[str]] = None,
+        parameter_names: Optional[Union[Dict[str, int], List[str]]] = None,
         # Deprecated...
         a=None,
         postargs=None,

--- a/src/emcee/ensemble.py
+++ b/src/emcee/ensemble.py
@@ -1,11 +1,10 @@
 # -*- coding: utf-8 -*-
 
 import warnings
-
+from itertools import count
 from typing import Dict, List, Optional, Union
 
 import numpy as np
-from itertools import count
 
 from .backends import Backend
 from .model import Model

--- a/src/emcee/ensemble.py
+++ b/src/emcee/ensemble.py
@@ -276,8 +276,9 @@ class EnsembleSampler(object):
             raise ValueError("'store' must be False when 'iterations' is None")
         # Interpret the input as a walker state and check the dimensions.
         state = State(initial_state, copy=True)
-        if np.shape(state.coords) != (self.nwalkers, self.ndim):
-            raise ValueError("incompatible input dimensions")
+        state_shape = np.shape(state.coords)
+        if state_shape != (self.nwalkers, self.ndim):
+            raise ValueError(f"incompatible input dimensions {state_shape}")
         if (not skip_initial_state_check) and (
             not walkers_independent(state.coords)
         ):

--- a/src/emcee/tests/unit/test_ensemble.py
+++ b/src/emcee/tests/unit/test_ensemble.py
@@ -6,7 +6,6 @@ from unittest import TestCase
 
 import numpy as np
 import pytest
-from scipy.stats import norm
 
 from emcee.ensemble import EnsembleSampler, ndarray_to_list_of_dicts
 
@@ -41,7 +40,7 @@ class TestNamedParameters(TestCase):
         var = pars["var"]
         if var <= 0:
             return -np.inf
-        return norm.logpdf(self.x, loc=mean, scale=np.sqrt(var)).sum()
+        return -0.5 * ((mean - self.x)**2 / var + np.log(2 * np.pi * var)).sum()
 
     def lnpdf_mixture(self, pars) -> np.float64:
         mean1 = pars["mean1"]
@@ -50,14 +49,14 @@ class TestNamedParameters(TestCase):
         var2 = pars["var2"]
         if var1 <= 0 or var2 <= 0:
             return -np.inf
-        return (
-            norm.logpdf(self.x, loc=mean1, scale=np.sqrt(var1)).sum()
-            + norm.logpdf(self.x + 3, loc=mean2, scale=np.sqrt(var2)).sum()
-        )
+        return -0.5 * (
+            (mean1 - self.x)**2 / var1 + np.log(2 * np.pi * var1)
+            + (mean2 - self.x - 3)**2 / var2 + np.log(2 * np.pi * var2)
+        ).sum()
 
     def setUp(self):
         # Draw some data from a unit Gaussian
-        self.x = norm.rvs(size=100)
+        self.x = np.random.randn(100)
         self.names = ["mean", "var"]
 
     def test_named_parameters(self):

--- a/src/emcee/tests/unit/test_ensemble.py
+++ b/src/emcee/tests/unit/test_ensemble.py
@@ -1,0 +1,129 @@
+"""
+Unit tests of some functionality in ensemble.py when the parameters are named
+"""
+import string
+from unittest import TestCase
+
+import numpy as np
+import pytest
+from scipy.stats import norm
+
+from emcee.ensemble import EnsembleSampler, ndarray_to_list_of_dicts
+
+
+class TestNP2ListOfDicts(TestCase):
+    def test_ndarray_to_list_of_dicts(self):
+        # Try different numbers of keys
+        for n_keys in [1, 2, 10, 26]:
+            keys = list(string.ascii_lowercase[:n_keys])
+            key_set = set(keys)
+            # Try different number of walker/procs
+            for N in [1, 2, 3, 10, 100]:
+                x = np.random.rand(N, n_keys)
+
+                LOD = ndarray_to_list_of_dicts(x, keys)
+                assert len(LOD) == N, "need 1 dict per row"
+                for i, dct in enumerate(LOD):
+                    assert dct.keys() == key_set, "keys are missing"
+                    for j, key in enumerate(keys):
+                        assert dct[key] == x[i, j], f"wrong value at {(i, j)}"
+
+
+class TestNamedParameters(TestCase):
+    """
+    Test that a keyword-based log-probability function instead of
+    a positional.
+    """
+
+    # Keyword based lnpdf
+    def lnpdf(self, pars) -> np.float64:
+        mean = pars["mean"]
+        var = pars["var"]
+        if var <= 0:
+            return -np.inf
+        return norm.logpdf(self.x, loc=mean, scale=np.sqrt(var)).sum()
+
+    def lnpdf_mixture(self, pars) -> np.float64:
+        mean1 = pars["mean1"]
+        var1 = pars["var1"]
+        mean2 = pars["mean2"]
+        var2 = pars["var2"]
+        if var1 <= 0 or var2 <= 0:
+            return -np.inf
+        return (
+            norm.logpdf(self.x, loc=mean1, scale=np.sqrt(var1)).sum()
+            + norm.logpdf(self.x + 3, loc=mean2, scale=np.sqrt(var2)).sum()
+        )
+
+    def setUp(self):
+        # Draw some data from a unit Gaussian
+        self.x = norm.rvs(size=100)
+        self.names = ["mean", "var"]
+
+    def test_named_parameters(self):
+        sampler = EnsembleSampler(
+            nwalkers=10,
+            ndim=len(self.names),
+            log_prob_fn=self.lnpdf,
+            parameter_names=self.names,
+        )
+        assert sampler.params_are_named
+        assert sampler.parameter_names == self.names
+
+    def test_asserts(self):
+        # ndim name mismatch
+        with pytest.raises(AssertionError):
+            _ = EnsembleSampler(
+                nwalkers=10,
+                ndim=len(self.names) - 1,
+                log_prob_fn=self.lnpdf,
+                parameter_names=self.names,
+            )
+
+        # duplicate names
+        with pytest.raises(AssertionError):
+            _ = EnsembleSampler(
+                nwalkers=10,
+                ndim=3,
+                log_prob_fn=self.lnpdf,
+                parameter_names=["a", "b", "a"],
+            )
+
+        # vectorize turned on
+        with pytest.raises(AssertionError):
+            _ = EnsembleSampler(
+                nwalkers=10,
+                ndim=len(self.names),
+                log_prob_fn=self.lnpdf,
+                parameter_names=self.names,
+                vectorize=True,
+            )
+
+    def test_compute_log_prob(self):
+        # Try different numbers of walkers
+        for N in [4, 8, 10]:
+            sampler = EnsembleSampler(
+                nwalkers=N,
+                ndim=len(self.names),
+                log_prob_fn=self.lnpdf,
+                parameter_names=self.names,
+            )
+            coords = np.random.rand(N, len(self.names))
+            lnps, _ = sampler.compute_log_prob(coords)
+            assert len(lnps) == N
+            assert lnps.dtype == np.float64
+
+    def test_compute_log_prob_mixture(self):
+        names = ["mean1", "var1", "mean2", "var2"]
+        # Try different numbers of walkers
+        for N in [8, 10, 20]:
+            sampler = EnsembleSampler(
+                nwalkers=N,
+                ndim=len(names),
+                log_prob_fn=self.lnpdf_mixture,
+                parameter_names=names,
+            )
+            coords = np.random.rand(N, len(names))
+            lnps, _ = sampler.compute_log_prob(coords)
+            assert len(lnps) == N
+            assert lnps.dtype == np.float64

--- a/src/emcee/tests/unit/test_ensemble.py
+++ b/src/emcee/tests/unit/test_ensemble.py
@@ -127,3 +127,19 @@ class TestNamedParameters(TestCase):
             lnps, _ = sampler.compute_log_prob(coords)
             assert len(lnps) == N
             assert lnps.dtype == np.float64
+
+    def test_run_mcmc(self):
+        # Sort of an integration test
+        n_walkers = 4
+        sampler = EnsembleSampler(
+            nwalkers=n_walkers,
+            ndim=len(self.names),
+            log_prob_fn=self.lnpdf,
+            parameter_names=self.names,
+        )
+        guess = np.random.rand(n_walkers, len(self.names))
+        n_steps = 50
+        results = sampler.run_mcmc(guess, n_steps)
+        assert results.coords.shape == (n_walkers, len(self.names))
+        chain = sampler.chain
+        assert chain.shape == (n_walkers, n_steps, len(self.names))


### PR DESCRIPTION
This PR closes #385 by giving support for named parameters in the `EnsembleSampler`.

Specifically this PR:
- allows a user to pass in a list of names (types as `str` but really can be anything) for the parameters to the constructor for `EnsembleSampler`. Checks are made to ensure that the number of unique names are `ndim`
- In the `EnsembleSampler.compute_log_prob` method, these names are used to reshape the parameters passed in to the method (having previously been generated by the `Move`) so that instead of an `ndarray` of shape `(nwalkers, ndim)` it becomes a list of length `nwalkers` of dictionaries of length `ndim`, with each key-value pair being the names and parameters
- A helper function was written to perform the `ndarray` -> `List[Dict[str, np.number]]` conversion, so that it could be tested separately from the `compute_log_prob` method (higher testable surface area)
- test of this functionality were placed in the newly created `src/emcee/tests/unit/test_ensemble.py` file. I tested the helper method, `compute_log_prob`, and `run_mcmc`
- very small bits of cleanup in `ensemble.py` to be more PEP8 compliant/more pythonic

As discussed in #385, this PR makes no assumptions about the kinds of likelihood functions or underlying models being utilized. It does not take gradients of the likelihood, nor does it break the API (frontend or backend) in any way. I believe the unit test in in the `TestNamedParametes` tests make it clear why this is useful. Positional bugs will be a thing of the past!

Support for named parameters could go a bit further. For example:
1. I didn't allow `vectorize=True` when naming the parameters. I guess the right thing to allow for would be if `vectorize=True` then we produce **one** dictionary where the keys are the parameter names and the values are 1D arrays of each parameter.
2. I did not implement support for parameter names in the `PTSampler`. IMO doing this would be "double work" and from a software perspective it would make more sense (IMO) to make an abstract `Sampler` class that handled the names, and that both the `EnsembleSampler` and `PTSampler` would subclass. But, this is obviously a non-trivial refactor (that I would be happy to contribute to).

Thanks @dfm for the discussion on #385. I look forward to your review.