### PR TITLE
Hdf5 swm rmode

### DIFF
--- a/docs/tutorials/swmr.ipynb
+++ b/docs/tutorials/swmr.ipynb
@@ -1,0 +1,480 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "(swmr)=\n",
+    "\n",
+    "# Reading an HDF5 file while it is being written\n",
+    "\n",
+    "This tutorial will show how it is possible to read from an HDF5 file while it is being written by the `HDFBackend` without incurring into crashes of the process that is currently writing to the file.\n",
+    "\n",
+    "By default, an HDF5 file can be either read or written and it is not possible to do both at the same time. Trying to do so anyway might lead to crashes of the `emcee` process because the information in the file is not properly synchronized.\n",
+    "\n",
+    "**Important note**: the relevance of this effect depends on how much time is spent on writing relative to the time taken to perform a step. If saving takes a relatively small time, it is less likely that you will encounter crashes of the emcee process."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%config InlineBackend.figure_format = \"retina\"\n",
+    "\n",
+    "from matplotlib import rcParams\n",
+    "rcParams[\"savefig.dpi\"] = 100\n",
+    "rcParams[\"figure.dpi\"] = 100\n",
+    "rcParams[\"font.size\"] = 20"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import multiprocessing as mp\n",
+    "import os\n",
+    "import time\n",
+    "import numpy as np\n",
+    "import emcee"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Example of failing to write and read at the same time."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let us consider the following.\n",
+    "\n",
+    "We want to perform an MCMC on some process: in a script we define the log-probability function and do the set up of emcee in a function."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def lnprob(x):\n",
+    "    time.sleep(0.0001)\n",
+    "    return 0.\n",
+    "\n",
+    "def writer():\n",
+    "    nwalkers = 100\n",
+    "    nsteps = 1000\n",
+    "    if os.path.isfile('backend.h5'):\n",
+    "        os.remove('backend.h5')\n",
+    "    backend = emcee.backends.HDFBackend('backend.h5')\n",
+    "    backend.reset(nwalkers,1)\n",
+    "    sampler = emcee.EnsembleSampler(nwalkers,1,lnprob,backend=backend)\n",
+    "    pos0 = np.ones(nwalkers) + ((np.random.random(nwalkers)-0.5)*2e-3)\n",
+    "    print(pos0.shape)\n",
+    "    sampler.run_mcmc(pos0[:, None],nsteps,progress=True,store=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We also have a script to read the chain from the HDF5 file."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def reader():\n",
+    "    backend = emcee.backends.HDFBackend('backend.h5',read_only=True)\n",
+    "    chain = backend.get_chain()\n",
+    "    print(chain.shape)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now, we start the chain in the background, with the help of the `multiprocessing` module."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(100,)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      " 16%|██████████▋                                                      | 164/1000 [00:03<00:18, 44.11it/s]\n",
+      "Process Process-2:\n",
+      "Traceback (most recent call last):\n",
+      "  File \"/home/ale/miniconda3/envs/emceefork/lib/python3.9/multiprocessing/process.py\", line 315, in _bootstrap\n",
+      "    self.run()\n",
+      "  File \"/home/ale/miniconda3/envs/emceefork/lib/python3.9/multiprocessing/process.py\", line 108, in run\n",
+      "    self._target(*self._args, **self._kwargs)\n",
+      "  File \"/tmp/ipykernel_17208/3509143556.py\", line 15, in writer\n",
+      "    sampler.run_mcmc(pos0[:, None],nsteps,progress=True,store=True)\n",
+      "  File \"/home/ale/Documenti/DOTTORATO/Progetti/emcee/src/emcee/ensemble.py\", line 438, in run_mcmc\n",
+      "    for results in self.sample(initial_state, iterations=nsteps, **kwargs):\n",
+      "  File \"/home/ale/Documenti/DOTTORATO/Progetti/emcee/src/emcee/ensemble.py\", line 405, in sample\n",
+      "    self.backend.save_step(state, accepted)\n",
+      "  File \"/home/ale/Documenti/DOTTORATO/Progetti/emcee/src/emcee/backends/hdf.py\", line 292, in save_step\n",
+      "    with self.open(\"a\") as f:\n",
+      "  File \"/home/ale/Documenti/DOTTORATO/Progetti/emcee/src/emcee/backends/hdf.py\", line 116, in open\n",
+      "    f = h5py.File(self.filename, mode, libver=libver, swmr=swmr)\n",
+      "  File \"/home/ale/miniconda3/envs/emceefork/lib/python3.9/site-packages/h5py/_hl/files.py\", line 444, in __init__\n",
+      "    fid = make_fid(name, mode, userblock_size,\n",
+      "  File \"/home/ale/miniconda3/envs/emceefork/lib/python3.9/site-packages/h5py/_hl/files.py\", line 211, in make_fid\n",
+      "    fid = h5f.open(name, h5f.ACC_RDWR, fapl=fapl)\n",
+      "  File \"h5py/_objects.pyx\", line 54, in h5py._objects.with_phil.wrapper\n",
+      "  File \"h5py/_objects.pyx\", line 55, in h5py._objects.with_phil.wrapper\n",
+      "  File \"h5py/h5f.pyx\", line 100, in h5py.h5f.open\n",
+      "BlockingIOError: [Errno 11] Unable to open file (unable to lock file, errno = 11, error message = 'Resource temporarily unavailable')\n"
+     ]
+    }
+   ],
+   "source": [
+    "writer_proc = mp.Process(target=writer)\n",
+    "writer_proc.start()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If for any reason you want to stop the reader, please uncomment the following cell and run it."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#writer_proc.terminate()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "While the chain is running, we want to check on the status of the chain, se we read it."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(50, 100, 1)\n"
+     ]
+    }
+   ],
+   "source": [
+    "reader()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In case the function call above worked without causing problems, let us try repeating the read several times in succession.  If instead the reader already crashed, then running the cell below is not needed and you should read further down."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(77, 100, 1)\n",
+      "Could not read from the backend.\n",
+      "Could not read from the backend.\n",
+      "(144, 100, 1)\n",
+      "(164, 100, 1)\n",
+      "The writer crashed after 5 tries.\n"
+     ]
+    }
+   ],
+   "source": [
+    "imax=50\n",
+    "i=0\n",
+    "while writer_proc.is_alive():\n",
+    "    i+=1\n",
+    "    try:\n",
+    "        reader()\n",
+    "    except:\n",
+    "        print(\"Could not read from the backend.\")\n",
+    "    if i>=imax:\n",
+    "        break\n",
+    "    time.sleep(0.5)\n",
+    "if i<imax and writer_proc.exitcode not in [0,None]:\n",
+    "    print(\"The writer crashed after {} tries.\".format(i))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "What very likely happened is that the cell above produced two kinds of outputs:\n",
+    "\n",
+    "- `\"Could not read from the backend.\"`, which means that the reader threw an exception while opening the file for reading. This happens when the file is read while the writer is in the middle of writing.\n",
+    "- `\"The writer died after N tries.\"`, and it shows that the writer crashed trying to open the file while it was already opened by the reader.\n",
+    "\n",
+    "The take home message is that without precautions _it is not safe to read an HDF5 file while it is being written_."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## How to read while the file is being written\n",
+    "\n",
+    "To completely avoid crashing the writer and interrupting a possibly long-running chain there are two things that have to be done:\n",
+    "1) turn on the Single Writer Multiple Reader (SWMR) mode\n",
+    "2) deactivate the HDF5 file locking mechanism when reading"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 1. Activating SWMR\n",
+    "\n",
+    "The SWMR mode has to be activated bith for the writer and the reader. Taking code from the above example, you would have to use\n",
+    "```python\n",
+    "backend = emcee.backends.HDFBackend('backend.h5',swmr=True)\n",
+    "```\n",
+    "for the writer and\n",
+    "```python\n",
+    "backend = emcee.backends.HDFBackend('backend.h5',read_only=True, swmr=True)\n",
+    "```\n",
+    "for the reader."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "### 2. Deactivating the file locking\n",
+    "\n",
+    "When running a chain, `emcee` opens and closes the HDF5 file of the backend at each step. This is an issue, because it is important that the writer opens the file before the reader can read it. Under the hood, there is a file locking mechanism which prevents mistakes when dealing with multiple processes accessing the file, and the writer has to receive the lock to be able to actually write, otherwise it will crash. The solution is to remove the locking mechanism from the reader, which is as simple as including\n",
+    "```python\n",
+    "import os\n",
+    "os.environ['HDF5_USE_FILE_LOCKING'] = 'FALSE'\n",
+    "```\n",
+    "in the script that reads the file."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### A word of warning\n",
+    "\n",
+    "Due to the complex oeprations performed by HDF, it might still happen that the reader crashes while trying to read the file. This, as of today, is anavoidable, but also a minor inconvenience compared to crasing the writer process."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## A complete solution\n",
+    "\n",
+    "We show below a complete, working solution that does not crash the writer."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def writer_fixed():\n",
+    "    nwalkers = 100\n",
+    "    nsteps = 1000\n",
+    "    if os.path.isfile('backend.h5'):\n",
+    "        os.remove('backend.h5')\n",
+    "    # write to backend with SWMR mode active\n",
+    "    backend = emcee.backends.HDFBackend('backend.h5',swmr=True)\n",
+    "    backend.reset(nwalkers,1)\n",
+    "    sampler = emcee.EnsembleSampler(nwalkers,1,lnprob,backend=backend)\n",
+    "    pos0 = np.ones(nwalkers) + ((np.random.random(nwalkers)-0.5)*2e-3)\n",
+    "    print(pos0.shape)\n",
+    "    sampler.run_mcmc(pos0[:, None],nsteps,progress=True,store=True)\n",
+    "    \n",
+    "def reader_fixed():\n",
+    "    # read from backend with SWMR mode active\n",
+    "    backend = emcee.backends.HDFBackend('backend.h5',read_only=True,swmr=True)\n",
+    "    chain = backend.get_chain()\n",
+    "    print(chain.shape)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(100,)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|████████████████████████████████████████████████████████████████| 1000/1000 [00:23<00:00, 43.18it/s]\n"
+     ]
+    }
+   ],
+   "source": [
+    "writer_proc = mp.Process(target=writer_fixed)\n",
+    "writer_proc.start()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(30, 100, 1)\n",
+      "(51, 100, 1)\n",
+      "(71, 100, 1)\n",
+      "(93, 100, 1)\n",
+      "Could not read from the backend.\n",
+      "(137, 100, 1)\n",
+      "Could not read from the backend.\n",
+      "(180, 100, 1)\n",
+      "(202, 100, 1)\n",
+      "(223, 100, 1)\n",
+      "Could not read from the backend.\n",
+      "(266, 100, 1)\n",
+      "(289, 100, 1)\n",
+      "(311, 100, 1)\n",
+      "(334, 100, 1)\n",
+      "(356, 100, 1)\n",
+      "(378, 100, 1)\n",
+      "(399, 100, 1)\n",
+      "(421, 100, 1)\n",
+      "Could not read from the backend.\n",
+      "(462, 100, 1)\n",
+      "Could not read from the backend.\n",
+      "Could not read from the backend.\n",
+      "Could not read from the backend.\n",
+      "(551, 100, 1)\n",
+      "Could not read from the backend.\n",
+      "(596, 100, 1)\n",
+      "(618, 100, 1)\n",
+      "(639, 100, 1)\n",
+      "(660, 100, 1)\n",
+      "(681, 100, 1)\n",
+      "(703, 100, 1)\n",
+      "(725, 100, 1)\n",
+      "(748, 100, 1)\n",
+      "(770, 100, 1)\n",
+      "(792, 100, 1)\n",
+      "Could not read from the backend.\n",
+      "Could not read from the backend.\n",
+      "(856, 100, 1)\n",
+      "(878, 100, 1)\n",
+      "(899, 100, 1)\n",
+      "(920, 100, 1)\n",
+      "(943, 100, 1)\n",
+      "(964, 100, 1)\n",
+      "Could not read from the backend.\n",
+      "The writer did not crash.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# set the environment variable\n",
+    "os.environ['HDF5_USE_FILE_LOCKING'] = 'FALSE'\n",
+    "imax=500\n",
+    "i=0\n",
+    "while writer_proc.is_alive():\n",
+    "    i+=1\n",
+    "    try:\n",
+    "        reader_fixed()\n",
+    "    except:\n",
+    "        print(\"Could not read from the backend.\")\n",
+    "    if i>=imax:\n",
+    "        break\n",
+    "    time.sleep(0.5)\n",
+    "if i<imax and writer_proc.exitcode not in [0,None]:\n",
+    "    print(\"The writer crashed after {} tries.\".format(i))\n",
+    "else:\n",
+    "    print(\"The writer did not crash.\")\n",
+    "del os.environ['HDF5_USE_FILE_LOCKING'] # we remove the environment variable to restore the initial environment"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The output you should see at this point should make it clear that, while the reader not always succeeded, the writer survived until the end. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python [conda env:emceefork]",
+   "language": "python",
+   "name": "conda-env-emceefork-py"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
The SWMR feature of HDF5 has been implemented in the HDFBackend and is activated setting the `swmr` argument to `True`. The process reading the file should not only use the SWMR mode but also set the environment variable `HDF5_USE_FILE_LOCKING="FALSE"`.

Let me know if I should change anything I have added.