### PR TITLE
Update link to Goodman & Weare 2010

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,7 +3,7 @@ emcee
 
 **emcee** is an MIT licensed pure-Python implementation of Goodman & Weare's
 `Affine Invariant Markov chain Monte Carlo (MCMC) Ensemble sampler
-<https://msp.berkeley.edu/camcos/2010/5-1/p04.xhtml>`_ and these pages will
+<https://msp.org/camcos/2010/5-1/p04.xhtml>`_ and these pages will
 show you how to use it.
 
 This documentation won't teach you too much about MCMC but there are a lot


### PR DESCRIPTION
Hi,

Relatively new user here, and I've been noticing that the URL to Goodman & Weare (2010) on the front page of the docs is broken. Wanted to help and noticed it's an easy fix, so hopefully this PR points the link to the right place now.

Let me know if there's anything else I should change!