### PR TITLE
Pass on random generator to KDE resample method

### DIFF
--- a/src/emcee/moves/kde.py
+++ b/src/emcee/moves/kde.py
@@ -38,6 +38,6 @@ class KDEMove(RedBlueMove):
     def get_proposal(self, s, c, random):
         c = np.concatenate(c, axis=0)
         kde = gaussian_kde(c.T, bw_method=self.bw_method)
-        q = kde.resample(len(s))
+        q = kde.resample(len(s), random)
         factor = kde.logpdf(s.T) - kde.logpdf(q)
         return q.T, factor


### PR DESCRIPTION
Currently, the random generator in the `get_proposal` method for the `KDEMove` is not used when taking samples from the KDE. This is problematic since we cannot run emcee in a reproducible way. This PR fixes this by passing on the random generator to the KDE resampling method, so that sampling is reproducible. 