### PR TITLE
Fix longdouble tests by seeding np.random

### DIFF
--- a/src/emcee/tests/integration/test_longdouble.py
+++ b/src/emcee/tests/integration/test_longdouble.py
@@ -9,6 +9,7 @@ def test_longdouble_doesnt_crash_bug_312():
     def log_prob(x, ivar):
         return -0.5 * np.sum(ivar * x**2)
 
+    np.random.seed(0)
     ndim, nwalkers = 5, 20
     ivar = 1.0 / np.random.rand(ndim).astype(np.longdouble)
     p0 = np.random.randn(nwalkers, ndim).astype(np.longdouble)
@@ -29,6 +30,7 @@ def test_longdouble_actually_needed(cls):
         assert x.dtype == np.longdouble
         return -0.5 * np.sum(((x - mjd) / sigma) ** 2)
 
+    np.random.seed(0)
     ndim, nwalkers = 1, 20
     steps = 1000
     p0 = sigma * np.random.randn(nwalkers, ndim).astype(np.longdouble) + mjd


### PR DESCRIPTION
I'm not sure if this is hiding some other new issue, but it seems to at least do the trick locally.

Closes #438

/cc @aarchiba 