### PR TITLE
Vectorized named parameters and generalized allowed input

### DIFF
--- a/src/emcee/ensemble.py
+++ b/src/emcee/ensemble.py
@@ -170,7 +170,7 @@ class EnsembleSampler(object):
 
             # Don't support vectorizing yet
             msg = "named parameters with vectorization unsupported for now"
-            assert not self.vectorize, msg
+            # assert not self.vectorize, msg
 
             # Check for duplicate names
             dupes = set()
@@ -473,7 +473,10 @@ class EnsembleSampler(object):
 
         # If the parmaeters are named, then switch to dictionaries
         if self.params_are_named:
-            p = ndarray_to_list_of_dicts(p, self.parameter_names)
+            if self.vectorize:
+                p = ndarray_to_dict(p, self.parameter_names)
+            else:
+                p = ndarray_to_list_of_dicts(p, self.parameter_names)
 
         # Run the log-probability calculations (optionally in parallel).
         if self.vectorize:
@@ -664,6 +667,10 @@ def _scaled_cond(a):
         return np.inf
     c = b / bsum
     return np.linalg.cond(c.astype(float))
+
+
+def ndarray_to_dict(x, key_map):
+    return {key: x[..., val] for key, val in key_map.items()}
 
 
 def ndarray_to_list_of_dicts(

--- a/src/emcee/ensemble.py
+++ b/src/emcee/ensemble.py
@@ -2,7 +2,7 @@
 
 import warnings
 from itertools import count
-from typing import Dict, List, Optional, Union, Iterable, Sequence
+from typing import Dict, Iterable, List, Optional, Sequence, Union
 
 import numpy as np
 

--- a/src/emcee/ensemble.py
+++ b/src/emcee/ensemble.py
@@ -2,7 +2,7 @@
 
 import warnings
 from itertools import count
-from typing import Dict, List, Optional, Union
+from typing import Dict, List, Optional, Union, Iterable, Sequence
 
 import numpy as np
 
@@ -14,8 +14,6 @@ from .state import State
 from .utils import deprecated, deprecation_warning
 
 __all__ = ["EnsembleSampler", "walkers_independent"]
-
-from collections.abc import Iterable, Sequence
 
 ParameterNamesT = Union[
     Sequence[str], Dict[str, Union[slice, int, Sequence[int]]]

--- a/src/emcee/ensemble.py
+++ b/src/emcee/ensemble.py
@@ -17,7 +17,9 @@ __all__ = ["EnsembleSampler", "walkers_independent"]
 
 from collections.abc import Iterable, Sequence
 
-ParameterNamesT = Union[Sequence[str], Dict[str, Union[slice, int, Sequence[int]]]]
+ParameterNamesT = Union[
+    Sequence[str], Dict[str, Union[slice, int, Sequence[int]]]
+]
 
 
 class EnsembleSampler(object):
@@ -169,19 +171,20 @@ class EnsembleSampler(object):
                 parameter_names = dict(zip(parameter_names, range(ndim)))
 
             indices = np.arange(ndim)
-            indexed = np.hstack([
-                indices[slc].ravel()
-                for slc in parameter_names.values()
-            ])
+            indexed = np.hstack(
+                [indices[slc].ravel() for slc in parameter_names.values()]
+            )
 
             if len(indexed) != ndim:
                 raise ValueError(
                     "`parameter_names` does not specify indices for"
-                    f" {ndim} parameters")
+                    f" {ndim} parameters"
+                )
             if set(indexed) != set(indices):
                 raise ValueError(
                     "`parameter_names` does not specify indices"
-                    f" 0 through {ndim-1}")
+                    f" 0 through {ndim-1}"
+                )
 
             self.parameter_names = parameter_names
 


### PR DESCRIPTION
This first adds support for vectorized named parameters. I also figured requiring the dict input to have values of type `list[int]` was needlessly restrictive, so I generalized it to allow slices, ints, or arbitrary sequences of ints. This includes multidimensional arrays, i.e., the named parameters now can have arbitrary shapes (which I think was originally desired in #386).

I also simplified the input validation (and replaced `asserts` with exceptions)---the messages could be more specific (e.g., "you have too many/too few/duplicate indices"), but I think they're sufficient as is. So far as I have thought of, the one kind of semi-invalid input that could sneak through is overslicing, i.e., passing `{"x": slice(ndim+1)}`. Presumably this would still, say, trigger an exception in `log_prob` if one was really expecting `x` to have size larger than `ndim`.

I will add tests for the extra cases allowed, I just put this together quickly (and got it working for my use case) and wanted to post for feedback.

Small note: I removed the import try/except for python 2 when I added an import from `collections.abc`.

(Edit: force pushed to replace checks for `Iterable`s with `Sequences` as dictionaries are the former but not the latter.)