### PR TITLE
Fix integrated_time docstring

### DIFF
--- a/src/emcee/autocorr.py
+++ b/src/emcee/autocorr.py
@@ -46,7 +46,7 @@ def auto_window(taus, c):
     return len(taus) - 1
 
 
-def integrated_time(x, c=5, tol=50, quiet=False):
+def integrated_time(x, c=5, tol=50, quiet=False, has_walkers=True):
     """Estimate the integrated autocorrelation time of a time series.
 
     This estimate uses the iterative procedure described on page 16 of
@@ -54,9 +54,11 @@ def integrated_time(x, c=5, tol=50, quiet=False):
     determine a reasonable window size.
 
     Args:
-        x: The time series. If multidimensional, set the time axis using the
-            ``axis`` keyword argument and the function will be computed for
-            every other axis.
+        x (numpy.ndarray): The time series. If 2-dimensional, the array
+            dimesions are interpreted as ``(n_step, n_walker)`` unless
+            ``has_walkers==False``, in which case they are interpreted as
+            ``(n_step, n_param)``. If 3-dimensional, the dimensions are
+            interperted as ``(n_step, n_walker, n_param)``.
         c (Optional[float]): The step size for the window search. (default:
             ``5``)
         tol (Optional[float]): The minimum number of autocorrelation times
@@ -64,10 +66,13 @@ def integrated_time(x, c=5, tol=50, quiet=False):
         quiet (Optional[bool]): This argument controls the behavior when the
             chain is too short. If ``True``, give a warning instead of raising
             an :class:`AutocorrError`. (default: ``False``)
+        has_walkers (Optional[bool]): Whether the last axis should be
+            interpreted as walkers or parameters if ``x`` has 2 dimensions.
+            (default: ``True``)
 
     Returns:
         float or array: An estimate of the integrated autocorrelation time of
-            the time series ``x`` computed along the axis ``axis``.
+            the time series ``x``.
 
     Raises
         AutocorrError: If the autocorrelation time can't be reliably estimated
@@ -79,7 +84,10 @@ def integrated_time(x, c=5, tol=50, quiet=False):
     if len(x.shape) == 1:
         x = x[:, np.newaxis, np.newaxis]
     if len(x.shape) == 2:
-        x = x[:, :, np.newaxis]
+        if not has_walkers:
+            x = x[:, np.newaxis, :]
+        else:
+            x = x[:, :, np.newaxis]
     if len(x.shape) != 3:
         raise ValueError("invalid dimensions")
 

--- a/src/emcee/tests/unit/test_autocorr.py
+++ b/src/emcee/tests/unit/test_autocorr.py
@@ -28,6 +28,13 @@ def test_nd(seed=1234, ndim=3, N=150000):
     assert np.all(np.abs(tau - 19.0) / 19.0 < 0.2)
 
 
+def test_nd_without_walkers(seed=1234, ndim=3, N=10000):
+    x = get_chain(seed=seed, ndim=ndim, N=N)
+    tau1 = integrated_time(x[:, np.newaxis])
+    tau2 = integrated_time(x, has_walkers=False)
+    assert np.allclose(tau1, tau2)
+
+
 def test_too_short(seed=1234, ndim=3, N=100):
     x = get_chain(seed=seed, ndim=ndim, N=N)
     with pytest.raises(AutocorrError):

--- a/src/emcee/tests/unit/test_autocorr.py
+++ b/src/emcee/tests/unit/test_autocorr.py
@@ -46,10 +46,9 @@ def test_autocorr_multi_works():
     np.random.seed(42)
     xs = np.random.randn(16384, 2)
 
-    # This throws exception unconditionally in buggy impl's
-    acls_multi = integrated_time(xs)
+    acls_multi = integrated_time(xs[:, np.newaxis])
     acls_single = np.array(
         [integrated_time(xs[:, i]) for i in range(xs.shape[1])]
-    )
+    ).squeeze()
 
-    assert np.all(np.abs(acls_multi - acls_single) < 2)
+    assert np.allclose(acls_multi, acls_single)


### PR DESCRIPTION
This PR addresses issue #337 by removing references to the `axis` keyword in the `integrated_time` docstring. It also adds a `has_walkers` keyword argument to make the routine more intuitive to use for cases where the time series does not contain multiple walkers (e.g. a single MH chain). It defaults to the old behaviour.

While writing a unit test I stumbled upon this test:
https://github.com/dfm/emcee/blob/main/src/emcee/tests/unit/test_autocorr.py#L38-L48

Is this doing what it is supposed to? With the current API, the 2d `xs` is interpreted as the having 2 walkers and 1 parameter. So `integrated_time` returns a scalar. Running `integrated_time` for each of the entries separately gives an array, however. 
I think I fixed this in 40904efd99e56117c1e52af0eb9b619713e93acd but do let me know if I misunderstood what the test was supposed to be testing.