### PR TITLE
Fixed DEMove Implementation

### DIFF
--- a/src/emcee/moves/de.py
+++ b/src/emcee/moves/de.py
@@ -50,7 +50,7 @@ class DEMove(RedBlueMove):
         pairs = pairs[indices]
 
         # Compute diff vectors
-        diffs = np.diff(s[pairs], axis=1).squeeze(axis=1)  # (ns, ndim)
+        diffs = np.diff(c[pairs], axis=1).squeeze(axis=1)  # (ns, ndim)
 
         # Sample a gamma value for each walker following Nelson et al. (2013)
         gamma = self.g0 * (1 + self.sigma * random.randn(ns, 1))  # (ns, 1)


### PR DESCRIPTION
# Problem:

- I observed that the current implementation of DEMove, although stated to follow Nelson et al. 2013, does not actually align with the paper's approach. The existing implementation lacked affine-invariance, which is fixed in Nelson's paper.
- There was potential to optimize performance via vectorization.

# Changes

Changes are only made in the implementation of DEMove in de.py.

- **Alignment with Nelson et al. 2013**:
Fixed the discrepancy between the stated and actual approaches. The normal noise $\epsilon \sim N(0, \sigma^2)$ used to be added to the proposal as per $\gamma_0 (x_i - x_j) + \epsilon$. In this case, $\sigma$ should be tuned for each dimension, which confronts the idea of affine-invariance. Now it defines the distribution over gamma: $\gamma = \gamma_0 (1 + \epsilon)$, which follows Nelson et al. 2013 and ensures affine-invariance. 

- **Vectorization for improved performance:**
Removed a loop in favor of vectorized operations. Benchmarks showed a speed boost ranging from 5-10 times depending on the number of walkers.

- **Simplified walker splitting:**
The new implementation requires splitting the walker population into two sets as opposed to the previous three-set approach. 
