### PR TITLE
Move proposals should match the dtype of original input

### DIFF
--- a/src/emcee/moves/de_snooker.py
+++ b/src/emcee/moves/de_snooker.py
@@ -32,7 +32,7 @@ class DESnookerMove(RedBlueMove):
         Ns = len(s)
         Nc = list(map(len, c))
         ndim = s.shape[1]
-        q = np.empty((Ns, ndim), dtype=np.float64)
+        q = np.empty_like(s)
         metropolis = np.empty(Ns, dtype=np.float64)
         for i in range(Ns):
             w = np.array([c[j][random.randint(Nc[j])] for j in range(3)])

--- a/src/emcee/moves/walk.py
+++ b/src/emcee/moves/walk.py
@@ -28,7 +28,7 @@ class WalkMove(RedBlueMove):
         c = np.concatenate(c, axis=0)
         Ns, Nc = len(s), len(c)
         ndim = s.shape[1]
-        q = np.empty((Ns, ndim), dtype=np.float64)
+        q = np.empty_like(s)
         s0 = Nc if self.s is None else self.s
         for i in range(Ns):
             inds = random.choice(Nc, s0, replace=False)


### PR DESCRIPTION
This PR addresses #483 for the `WalkMove` and `DESnookerMove` classes by replacing `np.empty` with `np.empty_like`, so the same datatype as the input walker positions is used in new proposals.