### PR TITLE
Fix moves documentation typos

### DIFF
--- a/docs/tutorials/moves.ipynb
+++ b/docs/tutorials/moves.ipynb
@@ -160,7 +160,7 @@
    "source": [
     "For \"lightly\" multimodal problems like these, some combination of the {class}`moves.DEMove` and {class}`moves.DESnookerMove` can often perform better than the default.\n",
     "In this case, let's use a weighted mixture of the two moves.\n",
-    "In deatil, this means that, at each step, we'll randomly select either a :class:`moves.DEMove` (with 80% probability) or a {class}`moves.DESnookerMove` (with 20% probability)."
+    "In detail, this means that, at each step, we'll randomly select either a {class}`moves.DEMove` (with 80% probability) or a {class}`moves.DESnookerMove` (with 20% probability)."
    ]
   },
   {


### PR DESCRIPTION
This commit fixes a display issue in the class reference, as well as a typo in the same sentence.