### PR TITLE
Address numpy deprecation warning

### DIFF
--- a/src/emcee/ensemble.py
+++ b/src/emcee/ensemble.py
@@ -489,10 +489,11 @@ class EnsembleSampler(object):
             results = list(map_func(self.log_prob_fn, p))
 
         try:
-            log_prob = np.array([float(l[0]) for l in results])
+            log_prob_elements = [l[0] for l in results]
+            log_prob = np.array([float(l.item() if hasattr(l, "item") else l) for l in log_prob_elements])
             blob = [l[1:] for l in results]
         except (IndexError, TypeError):
-            log_prob = np.array([float(l) for l in results])
+            log_prob = np.array([float(l.item() if hasattr(l, "item") else l) for l in results])
             blob = None
         else:
             # Get the blobs dtype

--- a/src/emcee/ensemble.py
+++ b/src/emcee/ensemble.py
@@ -490,10 +490,17 @@ class EnsembleSampler(object):
 
         try:
             log_prob_elements = [l[0] for l in results]
-            log_prob = np.array([float(l.item() if hasattr(l, "item") else l) for l in log_prob_elements])
+            log_prob = np.array(
+                [
+                    float(l.item() if hasattr(l, "item") else l)
+                    for l in log_prob_elements
+                ]
+            )
             blob = [l[1:] for l in results]
         except (IndexError, TypeError):
-            log_prob = np.array([float(l.item() if hasattr(l, "item") else l) for l in results])
+            log_prob = np.array(
+                [float(l.item() if hasattr(l, "item") else l) for l in results]
+            )
             blob = None
         else:
             # Get the blobs dtype

--- a/src/emcee/ensemble.py
+++ b/src/emcee/ensemble.py
@@ -490,17 +490,17 @@ class EnsembleSampler(object):
 
         try:
             log_prob_elements = [l[0] for l in results]
-            log_prob = np.array(
-                [
-                    float(l.item() if hasattr(l, "item") else l)
-                    for l in log_prob_elements
-                ]
-            )
+            if any(np.ndim(l) != 0 for l in log_prob_elements):
+                raise ValueError(
+                    "log_prob (first element of log_prob_fn output with "
+                    "blobs) must be a scalar."
+                )
+            log_prob = np.array([float(l) for l in log_prob_elements])
             blob = [l[1:] for l in results]
         except (IndexError, TypeError):
-            log_prob = np.array(
-                [float(l.item() if hasattr(l, "item") else l) for l in results]
-            )
+            if any(np.ndim(l) != 0 for l in results):
+                raise ValueError("log_prob_fn must always return a scalar.")
+            log_prob = np.array([float(l) for l in results])
             blob = None
         else:
             # Get the blobs dtype


### PR DESCRIPTION
I am seeing:

```
DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future. Ensure you extract a single element from your array before performing this operation. (Deprecated NumPy 1.25.)
```

from these lines, I think this would fix them. Not really sure how to add a test for that or if you'd prefer a diferent approach.