### PR TITLE
Removed a call to deprecated function EmceeSampler().chain()

### DIFF
--- a/src/emcee/tests/unit/test_ensemble.py
+++ b/src/emcee/tests/unit/test_ensemble.py
@@ -181,5 +181,5 @@ class TestNamedParameters(TestCase):
         n_steps = 50
         results = sampler.run_mcmc(guess, n_steps)
         assert results.coords.shape == (n_walkers, len(self.names))
-        chain = sampler.chain
-        assert chain.shape == (n_walkers, n_steps, len(self.names))
+        chain = sampler.get_chain()
+        assert chain.shape == (n_steps, n_walkers, len(self.names))


### PR DESCRIPTION
The file `src/emcee/tests/unit/test_ensemble.py` called the deprecated function `EmceeSampler().chain()` which produced a warning when running the tests. Figured it might help to replace that with a call to `EmceeSampler().get_chain()`.