### PR TITLE
Compat fix for older numpy versions

### DIFF
--- a/src/emcee/ensemble.py
+++ b/src/emcee/ensemble.py
@@ -21,6 +21,13 @@ except ImportError:
     # for py2.7, will be an Exception in 3.8
     from collections import Iterable
 
+try:
+    # Try to import from numpy.exceptions (available in NumPy 1.25 and later)
+    from numpy.exceptions import VisibleDeprecationWarning
+except ImportError:
+    # Fallback to the top-level numpy import (for older versions)
+    from numpy import VisibleDeprecationWarning
+
 
 class EnsembleSampler(object):
     """An ensemble MCMC sampler
@@ -511,7 +518,7 @@ class EnsembleSampler(object):
                 try:
                     with warnings.catch_warnings(record=True):
                         warnings.simplefilter(
-                            "error", np.exceptions.VisibleDeprecationWarning
+                            "error", VisibleDeprecationWarning
                         )
                         try:
                             dt = np.atleast_1d(blob[0]).dtype


### PR DESCRIPTION
Fixes: https://github.com/dfm/emcee/issues/515#issuecomment-2065800178

Before numpy 1.25, there was no `exceptions` namespace in numpy: https://numpy.org/doc/1.25/release/1.25.0-notes.html#numpy-now-has-an-np-exceptions-namespace

This PR fixes this for older numpy versions by importing `VisibleDeprecationWarning` from top level if `exceptions` is not present.