### PR TITLE
WIP: use Generator instead of RandomState

### DIFF
--- a/src/emcee/ensemble.py
+++ b/src/emcee/ensemble.py
@@ -73,6 +73,8 @@ class EnsembleSampler(object):
             names of individual parameters or groups of parameters. If
             specified, the ``log_prob_fn`` will recieve a dictionary of
             parameters, rather than a ``np.ndarray``.
+        rng (Optional):
+            int, :class:`np.random.Generator`, used for reproducibility.
 
     """
 
@@ -89,7 +91,7 @@ class EnsembleSampler(object):
         vectorize=False,
         blobs_dtype=None,
         parameter_names: Optional[Union[Dict[str, int], List[str]]] = None,
-        rng = None,
+        rng=None,
         # Deprecated...
         a=None,
         postargs=None,

--- a/src/emcee/ensemble.py
+++ b/src/emcee/ensemble.py
@@ -160,7 +160,7 @@ class EnsembleSampler(object):
             # Get the last random state
             state = self.backend.random_state
             if state is not None:
-                self._random.bit_generator.state = state
+                self.random_state = state
 
             # Grab the last step so that we can restart
             it = self.backend.iteration
@@ -225,7 +225,12 @@ class EnsembleSampler(object):
         def rng_dict(rng):
             bg_state = rng.bit_generator.state
             ss = rng.bit_generator.seed_seq
-            ss_dict = dict(entropy=ss.entropy, spawn_key=ss.spawn_key, pool_size=ss.pool_size, n_children_spawned=ss.n_children_spawned)
+            ss_dict = dict(
+                entropy=ss.entropy,
+                spawn_key=ss.spawn_key,
+                pool_size=ss.pool_size,
+                n_children_spawned=ss.n_children_spawned
+            )
             return dict(bg_state=bg_state, seed_seq=ss_dict)
         return rng_dict(self._random)
         # return self._random.bit_generator.state

--- a/src/emcee/moves/de.py
+++ b/src/emcee/moves/de.py
@@ -53,7 +53,7 @@ class DEMove(RedBlueMove):
         diffs = np.diff(c[pairs], axis=1).squeeze(axis=1)  # (ns, ndim)
 
         # Sample a gamma value for each walker following Nelson et al. (2013)
-        gamma = self.g0 * (1 + self.sigma * random.randn(ns, 1))  # (ns, 1)
+        gamma = self.g0 * (1 + self.sigma * random.standard_normal((ns, 1)))  # (ns, 1)
 
         # In this way, sigma is the standard deviation of the distribution of gamma,
         # instead of the standard deviation of the distribution of the proposal as proposed by Ter Braak (2006).

--- a/src/emcee/moves/de_snooker.py
+++ b/src/emcee/moves/de_snooker.py
@@ -35,7 +35,7 @@ class DESnookerMove(RedBlueMove):
         q = np.empty_like(s)
         metropolis = np.empty(Ns, dtype=np.float64)
         for i in range(Ns):
-            w = np.array([c[j][random.randint(Nc[j])] for j in range(3)])
+            w = np.array([c[j][random.integers(Nc[j])] for j in range(3)])
             random.shuffle(w)
             z, z1, z2 = w
             delta = s[i] - z

--- a/src/emcee/moves/gaussian.py
+++ b/src/emcee/moves/gaussian.py
@@ -87,13 +87,13 @@ class _isotropic_proposal(object):
         return np.exp(rng.uniform(-self._log_factor, self._log_factor))
 
     def get_updated_vector(self, rng, x0):
-        return x0 + self.get_factor(rng) * self.scale * rng.randn(*(x0.shape))
+        return x0 + self.get_factor(rng) * self.scale * rng.standard_normal((x0.shape))
 
     def __call__(self, x0, rng):
         nw, nd = x0.shape
         xnew = self.get_updated_vector(rng, x0)
         if self.mode == "random":
-            m = (range(nw), rng.randint(x0.shape[-1], size=nw))
+            m = (range(nw), rng.integers(x0.shape[-1], size=nw))
         elif self.mode == "sequential":
             m = (range(nw), self.index % nd + np.zeros(nw, dtype=int))
             self.index = (self.index + 1) % nd
@@ -106,7 +106,7 @@ class _isotropic_proposal(object):
 
 class _diagonal_proposal(_isotropic_proposal):
     def get_updated_vector(self, rng, x0):
-        return x0 + self.get_factor(rng) * self.scale * rng.randn(*(x0.shape))
+        return x0 + self.get_factor(rng) * self.scale * rng.standard_normal((x0.shape))
 
 
 class _proposal(_isotropic_proposal):

--- a/src/emcee/moves/mh.py
+++ b/src/emcee/moves/mh.py
@@ -56,7 +56,7 @@ class MHMove(Move):
 
         # Loop over the walkers and update them accordingly.
         lnpdiff = new_log_probs - state.log_prob + factors
-        accepted = np.log(model.random.rand(nwalkers)) < lnpdiff
+        accepted = np.log(model.random.random(nwalkers)) < lnpdiff
 
         # Update the parameters
         new_state = State(q, log_prob=new_log_probs, blobs=new_blobs)

--- a/src/emcee/moves/red_blue.py
+++ b/src/emcee/moves/red_blue.py
@@ -97,7 +97,7 @@ class RedBlueMove(Move):
                 zip(all_inds[S1], factors, new_log_probs)
             ):
                 lnpdiff = f + nlp - state.log_prob[j]
-                if lnpdiff > np.log(model.random.rand()):
+                if lnpdiff > np.log(model.random.random()):
                     accepted[j] = True
 
             new_state = State(q, log_prob=new_log_probs, blobs=new_blobs)

--- a/src/emcee/moves/stretch.py
+++ b/src/emcee/moves/stretch.py
@@ -27,7 +27,7 @@ class StretchMove(RedBlueMove):
         c = np.concatenate(c, axis=0)
         Ns, Nc = len(s), len(c)
         ndim = s.shape[1]
-        zz = ((self.a - 1.0) * random.rand(Ns) + 1) ** 2.0 / self.a
+        zz = ((self.a - 1.0) * random.random(Ns) + 1) ** 2.0 / self.a
         factors = (ndim - 1.0) * np.log(zz)
-        rint = random.randint(Nc, size=(Ns,))
+        rint = random.integers(Nc, size=(Ns,))
         return c[rint] - (c[rint] - s) * zz[:, None], factors

--- a/src/emcee/tests/unit/test_backends.py
+++ b/src/emcee/tests/unit/test_backends.py
@@ -43,11 +43,10 @@ def run_sampler(
 ):
     if lp is None:
         lp = normal_log_prob_blobs if blobs else normal_log_prob
-    if seed is not None:
-        np.random.seed(seed)
-    coords = np.random.randn(nwalkers, ndim)
+    rng = np.random.default_rng(seed)
+    coords = rng.standard_normal((nwalkers, ndim))
     sampler = EnsembleSampler(
-        nwalkers, ndim, lp, backend=backend, blobs_dtype=dtype
+        nwalkers, ndim, lp, rng=rng, backend=backend, blobs_dtype=dtype
     )
     sampler.run_mcmc(coords, nsteps, thin_by=thin_by)
     return sampler
@@ -125,10 +124,7 @@ def test_backend(backend, dtype, blobs):
         last2 = sampler2.get_last_sample()
         assert np.allclose(last1.coords, last2.coords)
         assert np.allclose(last1.log_prob, last2.log_prob)
-        assert all(
-            np.allclose(l1, l2)
-            for l1, l2 in zip(last1.random_state[1:], last2.random_state[1:])
-        )
+        assert last1.random_state == last2.random_state
         if blobs:
             _custom_allclose(last1.blobs, last2.blobs)
         else:
@@ -141,12 +137,11 @@ def test_backend(backend, dtype, blobs):
 
 @pytest.mark.parametrize("backend,dtype", product(other_backends, dtypes))
 def test_reload(backend, dtype):
-    with backend() as backend1:
+    with (backend() as backend1):
         run_sampler(backend1, dtype=dtype)
 
         # Test the state
         state = backend1.random_state
-        np.random.set_state(state)
 
         # Load the file using a new backend object.
         backend2 = backends.HDFBackend(
@@ -156,11 +151,7 @@ def test_reload(backend, dtype):
         with pytest.raises(RuntimeError):
             backend2.reset(32, 3)
 
-        assert state[0] == backend2.random_state[0]
-        assert all(
-            np.allclose(a, b)
-            for a, b in zip(state[1:], backend2.random_state[1:])
-        )
+        assert state == backend2.random_state
 
         # Check all of the components.
         for k in ["chain", "log_prob", "blobs"]:
@@ -172,10 +163,7 @@ def test_reload(backend, dtype):
         last2 = backend2.get_last_sample()
         assert np.allclose(last1.coords, last2.coords)
         assert np.allclose(last1.log_prob, last2.log_prob)
-        assert all(
-            np.allclose(l1, l2)
-            for l1, l2 in zip(last1.random_state[1:], last2.random_state[1:])
-        )
+        assert last1.random_state == last2.random_state
         _custom_allclose(last1.blobs, last2.blobs)
 
         a = backend1.accepted
@@ -188,11 +176,11 @@ def test_restart(backend, dtype):
     # Run a sampler with the default backend.
     b = backends.Backend()
     run_sampler(b, dtype=dtype)
-    sampler1 = run_sampler(b, seed=None, dtype=dtype)
+    sampler1 = run_sampler(b, seed=2, dtype=dtype)
 
     with backend() as be:
         run_sampler(be, dtype=dtype)
-        sampler2 = run_sampler(be, seed=None, dtype=dtype)
+        sampler2 = run_sampler(be, seed=2, dtype=dtype)
 
         # Check all of the components.
         for k in ["chain", "log_prob", "blobs"]:
@@ -204,10 +192,7 @@ def test_restart(backend, dtype):
         last2 = sampler2.get_last_sample()
         assert np.allclose(last1.coords, last2.coords)
         assert np.allclose(last1.log_prob, last2.log_prob)
-        assert all(
-            np.allclose(l1, l2)
-            for l1, l2 in zip(last1.random_state[1:], last2.random_state[1:])
-        )
+        assert last1.random_state == last2.random_state
         _custom_allclose(last1.blobs, last2.blobs)
 
         a = sampler1.acceptance_fraction

--- a/src/emcee/tests/unit/test_backends.py
+++ b/src/emcee/tests/unit/test_backends.py
@@ -124,7 +124,7 @@ def test_backend(backend, dtype, blobs):
         last2 = sampler2.get_last_sample()
         assert np.allclose(last1.coords, last2.coords)
         assert np.allclose(last1.log_prob, last2.log_prob)
-        assert last1.random_state == last2.random_state
+        assert last1.random_state['bg_state'] == last2.random_state['bg_state']
         if blobs:
             _custom_allclose(last1.blobs, last2.blobs)
         else:
@@ -192,7 +192,7 @@ def test_restart(backend, dtype):
         last2 = sampler2.get_last_sample()
         assert np.allclose(last1.coords, last2.coords)
         assert np.allclose(last1.log_prob, last2.log_prob)
-        assert last1.random_state == last2.random_state
+        assert last1.random_state['bg_state'] == last2.random_state['bg_state']
         _custom_allclose(last1.blobs, last2.blobs)
 
         a = sampler1.acceptance_fraction

--- a/src/emcee/tests/unit/test_sampler.py
+++ b/src/emcee/tests/unit/test_sampler.py
@@ -135,9 +135,9 @@ def run_sampler(
     progress=False,
     store=True,
 ):
-    np.random.seed(seed)
-    coords = np.random.randn(nwalkers, ndim)
-    sampler = EnsembleSampler(nwalkers, ndim, normal_log_prob, backend=backend)
+    rng = np.random.default_rng(seed)
+    coords = rng.standard_normal((nwalkers, ndim))
+    sampler = EnsembleSampler(nwalkers, ndim, normal_log_prob, rng=rng, backend=backend)
     sampler.run_mcmc(
         coords,
         nsteps,

--- a/src/emcee/tests/unit/test_stretch.py
+++ b/src/emcee/tests/unit/test_stretch.py
@@ -16,12 +16,12 @@ def test_live_dangerously(nwalkers=32, nsteps=3000, seed=1234):
     warnings.filterwarnings("error")
 
     # Set up the random number generator.
-    np.random.seed(seed)
+    rng = np.random.default_rng(seed)
     state = State(
-        np.random.randn(nwalkers, 2 * nwalkers),
+        rng.standard_normal((nwalkers, 2 * nwalkers)),
         log_prob=np.random.randn(nwalkers),
     )
-    model = Model(None, lambda x: (np.zeros(len(x)), None), map, np.random)
+    model = Model(None, lambda x: (np.zeros(len(x)), None), map, rng)
     proposal = moves.StretchMove()
 
     # Test to make sure that the error is thrown if there aren't enough


### PR DESCRIPTION
This WIP PR provides a basis for using `np.random.Generator` instead of the legacy `RandomState`. (`RandomState` is not going away, but it's also not going to have improvements made to it)

Unfortunately merging this would create a large amount of back incompatibility. `Generator` and `RandomState` have very different ways of setting internal state.

This might be something to aim for a big version bump.