### PR TITLE
Update de_snooker.py

### DIFF
--- a/src/emcee/moves/de_snooker.py
+++ b/src/emcee/moves/de_snooker.py
@@ -40,7 +40,7 @@ class DESnookerMove(RedBlueMove):
             z, z1, z2 = w
             delta = s[i] - z
             norm = np.linalg.norm(delta)
-            u = delta / np.sqrt(norm)
+            u = delta / norm
             q[i] = s[i] + u * self.gammas * (np.dot(u, z1) - np.dot(u, z2))
             metropolis[i] = np.log(np.linalg.norm(q[i] - z)) - np.log(norm)
-        return q, 0.5 * (ndim - 1.0) * metropolis
+        return q, (ndim - 1.0) * metropolis


### PR DESCRIPTION

**Fix Unit Vector Calculation and Adjust Metropolis Calculation in `get_proposal`**

- The vector `delta` was normalized using `u = delta / np.sqrt(norm(delta))`.
   - This approach is mathematically incorrect because dividing by `sqrt(norm(delta))` does not produce a unit vector (a vector with magnitude 1).
   - As a result, the vector `u` had an incorrect magnitude, which could lead to:
     - Misaligned scaling in the generated proposals (`q`).
     - Errors in the Metropolis acceptance ratio due to incorrect distance calculations.

- **Fix:** 
   - The calculation has been corrected to divide `delta` by `norm(delta)`, ensuring it is a unit vector as intended.
   - The Metropolis acceptance criterion scaling factor was adjusted from `0.5 * (ndim - 1.0)` to `ndim - 1.0` accordingly.
