### PR TITLE
Add missing "is" to docs page (closes #537)

### DIFF
--- a/docs/user/install.rst
+++ b/docs/user/install.rst
@@ -4,7 +4,7 @@ Installation
 ============
 
 Since emcee is a pure Python module, it should be pretty easy to install.
-All you'll need `numpy <https://numpy.org/>`_.
+All you'll need is `numpy <https://numpy.org/>`_.
 
 .. note:: For pre-release versions of emcee, you need to follow the
     instructions in :ref:`source`.


### PR DESCRIPTION
On the [install page](https://emcee.readthedocs.io/en/stable/user/install/), the sentence `All you’ll need numpy.` was updated to `All you’ll need is numpy.`.